### PR TITLE
Refresh and aws secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ EXT_NAME=quack
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
 # Build HTTPFS for testing
-CORE_EXTENSIONS='httpfs'
+CORE_EXTENSIONS=''
 
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -7,6 +7,7 @@ duckdb_extension_load(aws
 )
 
 duckdb_extension_load(httpfs
-        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../duckdb_httpfs
-        INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/../duckdb_httpfs/extension/httpfs/include
+        GIT_URL https://github.com/duckdb/duckdb-httpfs
+        GIT_TAG main
+        INCLUDE_DIR extension/httpfs/include
 )

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -5,3 +5,8 @@ duckdb_extension_load(aws
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
     LOAD_TESTS
 )
+
+duckdb_extension_load(httpfs
+        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../duckdb_httpfs
+        INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/../duckdb_httpfs/extension/httpfs/include
+)

--- a/test/sql/aws_secret_aws.test
+++ b/test/sql/aws_secret_aws.test
@@ -1,0 +1,32 @@
+# name: test/sql/aws_secret_aws.test
+# description: test aws extension aws r2 secret
+# group: [aws]
+
+require aws
+
+require httpfs
+
+# Note this test is not very intelligent since we dont assume any profiles to be available
+
+statement ok
+CREATE SECRET s1 (
+    TYPE AWS,
+    PROVIDER credential_chain
+);
+
+query I
+SELECT name FROM which_secret('s3://haha/hoehoe.parkoe', 'aws')
+----
+s1
+
+statement ok
+set s3_endpoint='localhost:12345';
+
+# Ensures this test is independent of the DUCKDB_S3_USE_SSL env variable
+statement ok
+set s3_use_ssl=true;
+
+statement error
+from "s3://blabla/file.csv"
+----
+IO Error: Could not establish connection error for HTTP HEAD to 'https://blabla.localhost:12345/file.csv' with status

--- a/test/sql/env/aws_secret_refresh.test
+++ b/test/sql/env/aws_secret_refresh.test
@@ -1,0 +1,38 @@
+# name: test/sql/env/aws_secret_refresh.test
+# description: Tests secret refreshing
+# group: [secrets]
+
+require aws
+
+require httpfs
+
+require-env DUCKDB_AWS_TESTING_ENV_AVAILABLE
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+require-env AWS_DEFAULT_REGION
+
+
+# Let's try explicitly passing in the config provider
+statement ok
+CREATE SECRET env_test (
+    TYPE S3,
+    PROVIDER credential_chain,
+    REGION 'eu-west-2',
+    REFRESH 'auto'
+);
+
+statement ok
+SET enable_logging=true
+
+statement error
+FROM "s3://test-bucket-ceiveran/a1.csv";
+----
+
+# Secret refresh has been triggered
+query II
+SELECT log_level, message FROM duckdb_logs WHERE type='httpfs.SecretRefresh'
+----
+INFO	<REGEX>:Successfully refreshed secret: env_test, new key_id:.*

--- a/test/sql/env/aws_secret_refresh.test
+++ b/test/sql/env/aws_secret_refresh.test
@@ -28,7 +28,7 @@ statement ok
 SET enable_logging=true
 
 statement error
-FROM "s3://test-bucket-ceiveran/a1.csv";
+FROM "s3://test-bucket-ceiveran/lololasdklasdjk.csv";
 ----
 
 # Secret refresh has been triggered


### PR DESCRIPTION
This adds the `aws` secret type alias for s3 secret types and adds the new secret refreshing mechanism from https://github.com/duckdb/duckdb-httpfs/pull/21