### PR TITLE
Add external_id parameter for AWS credential chain

### DIFF
--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -60,7 +60,7 @@ static unique_ptr<KeyValueSecret> ConstructBaseS3Secret(vector<string> &prefix_p
 class DuckDBCustomAWSCredentialsProviderChain : public Aws::Auth::AWSCredentialsProviderChain {
 public:
 	explicit DuckDBCustomAWSCredentialsProviderChain(const string &credential_chain, const string &profile = "",
-	                                                 const string &assume_role_arn = "") {
+	                                                 const string &assume_role_arn = "", const string &external_id = "") {
 		auto chain_list = StringUtil::Split(credential_chain, ';');
 
 		for (const auto &item : chain_list) {
@@ -73,7 +73,12 @@ public:
 				if (!profile.empty()) {
 					AddProvider(std::make_shared<Aws::Auth::STSProfileCredentialsProvider>(profile));
 				} else if (!assume_role_arn.empty()) {
-					AddProvider(std::make_shared<Aws::Auth::STSAssumeRoleCredentialsProvider>(assume_role_arn, Aws::String(), Aws::String(), Aws::Auth::DEFAULT_CREDS_LOAD_FREQ_SECONDS, sts_client));
+					if (!external_id.empty()) {
+                        AddProvider(std::make_shared<Aws::Auth::STSAssumeRoleCredentialsProvider>(
+                            assume_role_arn, Aws::String(), external_id, Aws::Auth::DEFAULT_CREDS_LOAD_FREQ_SECONDS, sts_client));
+					} else {
+						AddProvider(std::make_shared<Aws::Auth::STSAssumeRoleCredentialsProvider>(assume_role_arn, Aws::String(), Aws::String(), Aws::Auth::DEFAULT_CREDS_LOAD_FREQ_SECONDS, sts_client));
+					}
 				} else {
 					// TODO: I don't think this does anything
 					AddProvider(std::make_shared<Aws::Auth::STSAssumeRoleWebIdentityCredentialsProvider>());
@@ -120,11 +125,12 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 
 	string profile = TryGetStringParam(input, "profile");
 	string assume_role = TryGetStringParam(input, "assume_role_arn");
+	string external_id = TryGetStringParam(input, "external_id");
 
 	if (input.options.find("chain") != input.options.end()) {
 		chain = TryGetStringParam(input, "chain");
 
-		DuckDBCustomAWSCredentialsProviderChain provider(chain, profile, assume_role);
+		DuckDBCustomAWSCredentialsProviderChain provider(chain, profile, assume_role, external_id);
 		credentials = provider.GetAWSCredentials();
 	} else {
 		if (input.options.find("profile") != input.options.end()) {
@@ -252,6 +258,7 @@ void CreateAwsSecretFunctions::Register(DatabaseInstance &instance) {
 		cred_chain_function.named_parameters["url_compatibility_mode"] = LogicalType::BOOLEAN;
 
 		cred_chain_function.named_parameters["assume_role_arn"] = LogicalType::VARCHAR;
+		cred_chain_function.named_parameters["external_id"] = LogicalType::VARCHAR;
 
 		cred_chain_function.named_parameters["refresh"] = LogicalType::VARCHAR;
 

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -74,8 +74,7 @@ public:
 					AddProvider(std::make_shared<Aws::Auth::STSProfileCredentialsProvider>(profile));
 				} else if (!assume_role_arn.empty()) {
 					if (!external_id.empty()) {
-                        AddProvider(std::make_shared<Aws::Auth::STSAssumeRoleCredentialsProvider>(
-                            assume_role_arn, Aws::String(), external_id, Aws::Auth::DEFAULT_CREDS_LOAD_FREQ_SECONDS, sts_client));
+						AddProvider(std::make_shared<Aws::Auth::STSAssumeRoleCredentialsProvider>(assume_role_arn, Aws::String(), external_id, Aws::Auth::DEFAULT_CREDS_LOAD_FREQ_SECONDS, sts_client));
 					} else {
 						AddProvider(std::make_shared<Aws::Auth::STSAssumeRoleCredentialsProvider>(assume_role_arn, Aws::String(), Aws::String(), Aws::Auth::DEFAULT_CREDS_LOAD_FREQ_SECONDS, sts_client));
 					}

--- a/test/sql/aws_secret_external_id.test
+++ b/test/sql/aws_secret_external_id.test
@@ -1,0 +1,30 @@
+# name: test/sql/aws_secret_external_id.test
+# description: test aws secrets with external_id parameter
+# group: [aws]
+
+require no_extension_autoloading "EXPECTED: Test relies on explicit INSTALL and LOAD"
+
+require aws
+
+require httpfs
+
+# Create a secret with external_id parameter
+statement ok
+CREATE SECRET s3_cred (
+    TYPE s3, 
+    PROVIDER credential_chain,
+    chain 'sts',
+    assume_role_arn 'arn:aws:iam::123456789012:role/test-role',
+    external_id 'test-external-id',
+    region 'us-west-2'
+)
+
+# Verify the secret was created
+query I
+SELECT secret_string FROM duckdb_secrets(redact=false) where name='s3_cred';
+----
+<REGEX>:.*endpoint=s3.amazonaws.com.*
+
+# Clean up
+statement ok
+DROP SECRET IF EXISTS s3_cred

--- a/test/sql/aws_secret_external_id.test
+++ b/test/sql/aws_secret_external_id.test
@@ -25,6 +25,12 @@ SELECT secret_string FROM duckdb_secrets(redact=false) where name='s3_cred';
 ----
 <REGEX>:.*endpoint=s3.amazonaws.com.*
 
+# Verify external_id is present
+query I
+SELECT count(*) FROM duckdb_secrets() where secret_string like '%test-external-id%';
+----
+1
+
 # Clean up
 statement ok
 DROP SECRET IF EXISTS s3_cred


### PR DESCRIPTION
This change adds support for the external_id parameter when using the AWS credential chain with the STS assume role provider.