### PR TITLE
If `profile` is present, pass into `ProcessCredentialsProvider`

### DIFF
--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -93,7 +93,11 @@ public:
 			} else if (item == "instance") {
 				AddProvider(std::make_shared<Aws::Auth::InstanceProfileCredentialsProvider>());
 			} else if (item == "process") {
-				AddProvider(std::make_shared<Aws::Auth::ProcessCredentialsProvider>());
+				if (profile.empty()) {
+					AddProvider(std::make_shared<Aws::Auth::ProcessCredentialsProvider>());
+				} else {
+					AddProvider(std::make_shared<Aws::Auth::ProcessCredentialsProvider>(profile.c_str()));
+				}
 			} else if (item == "config") {
 				if (profile.empty()) {
 					AddProvider(std::make_shared<Aws::Auth::ProfileConfigFileAWSCredentialsProvider>());


### PR DESCRIPTION
Fixes part of the confusion in #62 where the `profile` configuration option is not recognized when the `process` chain is used.

This will fix the case when the Secret is created like this:

```
CREATE OR REPLACE SECRET s3 (
  TYPE S3, 
  PROVIDER CREDENTIAL_CHAIN, 
  CHAIN 'process', 
  PROFILE 'duckdb-test'
);
```

and the `.aws/config` file looks like this:

```
[profile duckdb-test]
credential_process = /bin/sh -c '<a command that returns valid credentials>'
```
The `credentials_process` needs to return the credentials in the following [format](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-sourcing-external.html):

```
{
  "Version": 1,
  "AccessKeyId": "an AWS access key",
  "SecretAccessKey": "your AWS secret access key",
  "SessionToken": "the AWS session token for temporary credentials", 
  "Expiration": "ISO8601 timestamp when the credentials expire"
}  
```

However, the following setup will still not work because the `DefaultAWSCredentialsProviderChain` does not accept a selected profile and we are not able to pass in the selected profile. In that case configuration using an environment variable `AWS_PROFILE` is still required.

```
CREATE OR REPLACE SECRET s3 (TYPE S3, PROVIDER CREDENTIAL_CHAIN, PROFILE 'duckdb-test');
```