### PR TITLE
fix nil pointer on create GCS secret

### DIFF
--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -223,7 +223,7 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 
 	// Set endpoint defaults TODO: move to consumer side of secret
 	auto url_style_lu = result->secret_map.find("url_style");
-	if (url_style_lu == result->secret_map.end() || endpoint_lu->second.ToString().empty()) {
+	if (url_style_lu == result->secret_map.end() || url_style_lu->second.ToString().empty()) {
 		if (input.type == "gcs" || input.type == "r2") {
 			result->secret_map["url_style"] = "path";
 		}

--- a/test/sql/aws_secret_gcs.test
+++ b/test/sql/aws_secret_gcs.test
@@ -26,3 +26,10 @@ statement error
 from "gcs://a/b.csv"
 ----
 
+statement ok
+CREATE SECRET gcs_secret (
+    TYPE gcs,
+    PROVIDER credential_chain,
+    ENDPOINT "storage.googleapis.com",
+    URL_STYLE vhost
+);


### PR DESCRIPTION
Fix nil pointer deref when creating a GCS secret.

```
Use ".open FILENAME" to reopen on a persistent database.
D LOAD httpfs;
D CREATE or REPLACE SECRET secret (TYPE gcs, PROVIDER credential_chain, URL_STYLE vhost);
INTERNAL Error:
Invalid PhysicalType for GetTypeIdSize

Stack Trace:

0        _ZN6duckdb9ExceptionC2ENS_13ExceptionTypeERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 64
1        _ZN6duckdb13GetTypeIdSizeENS_12PhysicalTypeE + 288
2        _ZN6duckdb12VectorBuffer20CreateConstantVectorENS_12PhysicalTypeE + 28
3        _ZN6duckdb6Vector9ReferenceERKNS_5ValueE + 60
4        _ZNK6duckdb5Value9TryCastAsERNS_15CastFunctionSetERNS_20GetCastFunctionInputERKNS_11LogicalTypeERS0_PNSt3__112basic_stringIcNS9_11char_traitsIcEENS9_9allocatorIcEEEEb + 264
5        _ZNK6duckdb5Value6CastAsERNS_15CastFunctionSetERNS_20GetCastFunctionInputERKNS_11LogicalTypeEb + 204
6        _ZNK6duckdb5Value8ToStringEv + 136
7        _ZN6duckdbL34CreateAWSSecretFromCredentialChainERNS_13ClientContextERNS_17CreateSecretInputE + 5356
8        duckdb::SecretManager::CreateSecret(duckdb::ClientContext&, duckdb::CreateSecretInfo const&) + 520
9        duckdb::PhysicalCreateSecret::GetData(duckdb::ExecutionContext&, duckdb::DataChunk&, duckdb::OperatorSourceInput&) const + 56
10       duckdb::PipelineExecutor::FetchFromSource(duckdb::DataChunk&) + 124
11       duckdb::PipelineExecutor::Execute(unsigned long long) + 236
12       duckdb::PipelineTask::ExecuteTask(duckdb::TaskExecutionMode) + 236
13       duckdb::ExecutorTask::Execute(duckdb::TaskExecutionMode) + 160
14       duckdb::Executor::ExecuteTask(bool) + 252
15       duckdb::ClientContext::ExecuteTaskInternal(duckdb::ClientContextLock&, duckdb::BaseQueryResult&, bool) + 64
16       duckdb::PendingQueryResult::ExecuteInternal(duckdb::ClientContextLock&) + 60
17       duckdb::PendingQueryResult::Execute() + 56
18       duckdb_shell_sqlite3_print_duckbox + 368
19       duckdb_shell::ShellState::ExecutePreparedStatement(sqlite3_stmt*) + 964
20       duckdb_shell::ShellState::ExecuteSQL(char const*, char**) + 452
21       duckdb_shell::ShellState::RunOneSqlLine(char*) + 104
22       duckdb_shell::ShellState::ProcessInput() + 916
23       main + 3140
24       start + 6000

This error signals an assertion failure within DuckDB. This usually occurs due to unexpected conditions or errors in the program's logic.
For more information, see https://duckdb.org/docs/dev/internal_errors
```