### PR TITLE
apply patches for v1.4-andium

### DIFF
--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -1,7 +1,7 @@
 #include "aws_secret.hpp"
 
 #include "duckdb/common/case_insensitive_map.hpp"
-#include "duckdb/main/extension_util.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
 
 #include <aws/core/Aws.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
@@ -243,7 +243,7 @@ void CreateAwsSecretFunctions::InitializeCurlCertificates(DatabaseInstance &db) 
 	}
 }
 
-void CreateAwsSecretFunctions::Register(DatabaseInstance &instance) {
+void CreateAwsSecretFunctions::Register(ExtensionLoader &loader) {
 	vector<string> types = {"s3", "r2", "gcs", "aws"};
 
 	for (const auto &type : types) {
@@ -275,7 +275,7 @@ void CreateAwsSecretFunctions::Register(DatabaseInstance &instance) {
 		// Params for configuring the credential loading
 		cred_chain_function.named_parameters["profile"] = LogicalType::VARCHAR;
 
-		ExtensionUtil::RegisterFunction(instance, cred_chain_function);
+		loader.RegisterFunction(cred_chain_function);
 	}
 }
 

--- a/src/include/aws_extension.hpp
+++ b/src/include/aws_extension.hpp
@@ -13,7 +13,7 @@ struct AwsSetCredentialsResult {
 
 class AwsExtension : public Extension {
 public:
-	void Load(DuckDB &db) override;
+	void Load(ExtensionLoader &db) override;
 	std::string Name() override;
 };
 

--- a/src/include/aws_secret.hpp
+++ b/src/include/aws_secret.hpp
@@ -6,10 +6,12 @@
 
 namespace duckdb {
 
+class ExtensionLoader;
+
 struct CreateAwsSecretFunctions {
 public:
 	//! Register all CreateSecretFunctions
-	static void Register(DatabaseInstance &instance);
+	static void Register(ExtensionLoader &instance);
 
 	//! WARNING: not thread-safe, to be called on extension initialization once
 	static void InitializeCurlCertificates(DatabaseInstance &db);


### PR DESCRIPTION
There is no `v1.4-andium` branch yet, but this applies the patches necessary for it (this was necessary for duckdb-iceberg, which needed to build against `duckdb/duckdb`'s `main` branch (which will become v1.4-andium at some point)