### PR TITLE
Pass profile into DefaultAWSCredentialsProviderChain and use it instead of ProfileConfigFileAWSCredentialsProvider

### DIFF
--- a/src/aws_extension.cpp
+++ b/src/aws_extension.cpp
@@ -31,7 +31,7 @@ static AwsSetCredentialsResult TrySetAwsCredentials(DBConfig &config, const stri
 	auto s3_config = Aws::Client::ClientConfiguration(profile.c_str());
 	auto region = s3_config.region;
 
-	// TODO: We would also like to get the endpoint here, but it's currently not supported by the AWS SDK:
+	// TODO: We would also like to get the endpoint here, but it's currently not supported by the AWS Sdk:
 	// 		 https://github.com/aws/aws-sdk-cpp/issues/2587
 
 	AwsSetCredentialsResult ret;

--- a/src/aws_extension.cpp
+++ b/src/aws_extension.cpp
@@ -19,7 +19,9 @@ static AwsSetCredentialsResult TrySetAwsCredentials(DBConfig &config, const stri
 	if (!profile.empty()) {
 		// The user has specified a specific profile they want to use instead of the current profile specified by the
 		// system
-		Aws::Auth::ProfileConfigFileAWSCredentialsProvider provider(profile.c_str());
+		Aws::Client::ClientConfiguration::CredentialProviderConfiguration config;
+  		config.profile = profile.c_str()
+		Aws::Auth::DefaultAWSCredentialsProviderChain provider(config);
 		credentials = provider.GetAWSCredentials();
 	} else {
 		Aws::Auth::DefaultAWSCredentialsProviderChain provider;

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -220,7 +220,9 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 		credentials = provider.GetAWSCredentials();
 	} else {
 		if (input.options.find("profile") != input.options.end()) {
-			Aws::Auth::ProfileConfigFileAWSCredentialsProvider provider(profile.c_str());
+			Aws::Client::ClientConfiguration::CredentialProviderConfiguration config;
+  			config.profile = profile.c_str()
+			Aws::Auth::DefaultAWSCredentialsProviderChain provider(config);
 			credentials = provider.GetAWSCredentials();
 		} else {
 			Aws::Auth::DefaultAWSCredentialsProviderChain provider;


### PR DESCRIPTION
because https://github.com/aws/aws-sdk-cpp/pull/3492 is merged we can fix parts of https://github.com/duckdb/duckdb-aws/issues/62

How do I update the used version of aws-sdk-cpp? Current seems to be

`aws-sdk-cpp[cognito-identity,core,dynamodb,identity-management,kinesis,s3,sso,sts]:x64-linux-release@1.11.428`