### PR TITLE
Add web_identity chain type for IRSA support

### DIFF
--- a/scripts/duckdb-oidc-test.sh
+++ b/scripts/duckdb-oidc-test.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# duckdb-oidc-test.sh
+#
+# Sets up an OIDC test harness for duckdb-aws PR #136 (web_identity chain).
+# Uses Cognito as the OIDC provider; everything fits within the AWS Free Tier.
+#
+# Usage:
+#   ./duckdb-oidc-test.sh setup     # create resources, mint token, print env
+#   ./duckdb-oidc-test.sh token     # mint a fresh token (Cognito IDs last ~1h)
+#   ./duckdb-oidc-test.sh verify    # call sts:AssumeRoleWithWebIdentity
+#   ./duckdb-oidc-test.sh env       # print export lines (for `eval`)
+#   ./duckdb-oidc-test.sh status    # show current state
+#   ./duckdb-oidc-test.sh cleanup   # tear down all resources
+
+set -euo pipefail
+
+STATE_FILE="${STATE_FILE:-$HOME/.duckdb-oidc-test.state}"
+TOKEN_FILE="${TOKEN_FILE:-/tmp/duckdb-oidc-test-token}"
+TRUST_POLICY_FILE="/tmp/duckdb-oidc-test-trust.json"
+
+AWS_REGION="${AWS_REGION:-us-east-1}"
+POOL_NAME="${POOL_NAME:-duckdb-irsa-test}"
+CLIENT_NAME="${CLIENT_NAME:-duckdb-irsa-test-client}"
+USERNAME="${USERNAME:-tester}"
+PASSWORD="${PASSWORD:-TestPassword123!}"
+ROLE_NAME="${ROLE_NAME:-duckdb-irsa-test-role}"
+
+log()  { printf '\033[1;36m[%s]\033[0m %s\n' "$(date +%H:%M:%S)" "$*"; }
+warn() { printf '\033[1;33m[warn]\033[0m %s\n' "$*" >&2; }
+fail() { printf '\033[1;31m[fail]\033[0m %s\n' "$*" >&2; exit 1; }
+
+require() { command -v "$1" >/dev/null 2>&1 || fail "missing dependency: $1"; }
+
+load_state() {
+    [[ -f "$STATE_FILE" ]] || fail "no state at $STATE_FILE — run '$0 setup' first"
+    # shellcheck source=/dev/null
+    source "$STATE_FILE"
+}
+
+save_state() {
+    umask 077
+    cat > "$STATE_FILE" <<EOF
+USER_POOL_ID="$USER_POOL_ID"
+CLIENT_ID="$CLIENT_ID"
+OIDC_PROVIDER_ARN="$OIDC_PROVIDER_ARN"
+ROLE_ARN="$ROLE_ARN"
+ROLE_NAME="$ROLE_NAME"
+AWS_REGION="$AWS_REGION"
+ISSUER_HOST="$ISSUER_HOST"
+USERNAME="$USERNAME"
+PASSWORD="$PASSWORD"
+EOF
+}
+
+mint_token() {
+    local id_token
+    id_token=$(aws cognito-idp admin-initiate-auth \
+        --region "$AWS_REGION" \
+        --user-pool-id "$USER_POOL_ID" \
+        --client-id "$CLIENT_ID" \
+        --auth-flow ADMIN_USER_PASSWORD_AUTH \
+        --auth-parameters "USERNAME=$USERNAME,PASSWORD=$PASSWORD" \
+        --query 'AuthenticationResult.IdToken' --output text)
+
+    umask 077
+    printf '%s' "$id_token" > "$TOKEN_FILE"
+}
+
+cmd_setup() {
+    require aws
+    require openssl
+
+    if [[ -f "$STATE_FILE" ]]; then
+        fail "state file already exists at $STATE_FILE — run '$0 cleanup' first"
+    fi
+
+    log "checking AWS credentials"
+    aws sts get-caller-identity >/dev/null \
+        || fail "AWS CLI not authenticated — run 'aws configure' first"
+
+    ISSUER_HOST="cognito-idp.${AWS_REGION}.amazonaws.com"
+
+    log "creating Cognito user pool ($POOL_NAME)"
+    USER_POOL_ID=$(aws cognito-idp create-user-pool \
+        --region "$AWS_REGION" \
+        --pool-name "$POOL_NAME" \
+        --policies '{"PasswordPolicy":{"MinimumLength":8,"RequireUppercase":true,"RequireLowercase":true,"RequireNumbers":true,"RequireSymbols":true}}' \
+        --query 'UserPool.Id' --output text)
+    log "  USER_POOL_ID=$USER_POOL_ID"
+
+    log "creating Cognito app client"
+    CLIENT_ID=$(aws cognito-idp create-user-pool-client \
+        --region "$AWS_REGION" \
+        --user-pool-id "$USER_POOL_ID" \
+        --client-name "$CLIENT_NAME" \
+        --no-generate-secret \
+        --explicit-auth-flows ALLOW_ADMIN_USER_PASSWORD_AUTH ALLOW_REFRESH_TOKEN_AUTH \
+        --query 'UserPoolClient.ClientId' --output text)
+    log "  CLIENT_ID=$CLIENT_ID"
+
+    log "creating user $USERNAME"
+    aws cognito-idp admin-create-user \
+        --region "$AWS_REGION" \
+        --user-pool-id "$USER_POOL_ID" \
+        --username "$USERNAME" \
+        --message-action SUPPRESS >/dev/null
+
+    aws cognito-idp admin-set-user-password \
+        --region "$AWS_REGION" \
+        --user-pool-id "$USER_POOL_ID" \
+        --username "$USERNAME" \
+        --password "$PASSWORD" \
+        --permanent
+
+    log "fetching issuer TLS thumbprint"
+    THUMBPRINT=$(
+        echo | openssl s_client -servername "$ISSUER_HOST" \
+            -showcerts -connect "${ISSUER_HOST}:443" </dev/null 2>/dev/null \
+        | openssl x509 -fingerprint -sha1 -noout 2>/dev/null \
+        | awk -F'=' '{gsub(/[: \t\r\n]/, "", $2); print tolower($2)}'
+    )
+    if ! [[ "$THUMBPRINT" =~ ^[0-9a-f]{40}$ ]]; then
+        warn "thumbprint extraction produced '$THUMBPRINT' (length ${#THUMBPRINT})"
+        warn "falling back to Starfield Class 2 root CA thumbprint"
+        warn "(AWS auto-validates Cognito OIDC certs, the value is effectively a placeholder)"
+        THUMBPRINT="afe5d244a8d1194230ff479fe2f897bbcd7a8cb4"
+    fi
+    log "  thumbprint: $THUMBPRINT"
+
+    log "registering IAM OIDC identity provider"
+    OIDC_PROVIDER_ARN=$(aws iam create-open-id-connect-provider \
+        --url "https://${ISSUER_HOST}/${USER_POOL_ID}" \
+        --client-id-list "$CLIENT_ID" \
+        --thumbprint-list "$THUMBPRINT" \
+        --query 'OpenIDConnectProviderArn' --output text)
+    log "  OIDC_PROVIDER_ARN=$OIDC_PROVIDER_ARN"
+
+    log "creating IAM role $ROLE_NAME"
+    cat > "$TRUST_POLICY_FILE" <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Federated": "$OIDC_PROVIDER_ARN" },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "${ISSUER_HOST}/${USER_POOL_ID}:aud": "$CLIENT_ID"
+      }
+    }
+  }]
+}
+EOF
+    ROLE_ARN=$(aws iam create-role \
+        --role-name "$ROLE_NAME" \
+        --assume-role-policy-document "file://$TRUST_POLICY_FILE" \
+        --query 'Role.Arn' --output text)
+    log "  ROLE_ARN=$ROLE_ARN"
+
+    save_state
+
+    log "waiting 10s for IAM consistency"
+    sleep 10
+
+    log "minting initial OIDC token"
+    mint_token
+    log "  token written to $TOKEN_FILE ($(wc -c < "$TOKEN_FILE") bytes, valid ~1h)"
+
+    log "verifying trust chain via sts:AssumeRoleWithWebIdentity"
+    if aws sts assume-role-with-web-identity \
+        --role-arn "$ROLE_ARN" \
+        --role-session-name duckdb-irsa-test \
+        --web-identity-token "$(cat "$TOKEN_FILE")" \
+        --query 'Credentials.{AccessKeyId:AccessKeyId,Expiration:Expiration}' \
+        --output table >/dev/null 2>&1; then
+        log "trust chain OK"
+    else
+        warn "STS verify failed — IAM may still be propagating; rerun '$0 verify' in a moment"
+    fi
+
+    echo
+    echo "Setup complete. To use these credentials with duckdb:"
+    echo
+    echo "  eval \"\$($0 env)\""
+    echo
+    echo "Then run your duckdb-aws test. When done:"
+    echo
+    echo "  $0 cleanup"
+}
+
+cmd_token() {
+    require aws
+    load_state
+    log "minting fresh OIDC token"
+    mint_token
+    log "  token written to $TOKEN_FILE ($(wc -c < "$TOKEN_FILE") bytes, valid ~1h)"
+}
+
+cmd_verify() {
+    require aws
+    load_state
+    [[ -f "$TOKEN_FILE" ]] || fail "no token at $TOKEN_FILE — run '$0 token' first"
+
+    log "calling sts:AssumeRoleWithWebIdentity"
+    aws sts assume-role-with-web-identity \
+        --role-arn "$ROLE_ARN" \
+        --role-session-name duckdb-irsa-test \
+        --web-identity-token "$(cat "$TOKEN_FILE")" \
+        --query 'Credentials.{AccessKeyId:AccessKeyId,Expiration:Expiration}' \
+        --output table
+    log "credentials minted successfully"
+}
+
+cmd_env() {
+    load_state
+    [[ -f "$TOKEN_FILE" ]] || fail "no token at $TOKEN_FILE — run '$0 token' first"
+    cat <<EOF
+export AWS_ROLE_ARN="$ROLE_ARN"
+export AWS_WEB_IDENTITY_TOKEN_FILE="$TOKEN_FILE"
+export AWS_ROLE_SESSION_NAME=duckdb-irsa-test
+export AWS_DEFAULT_REGION="$AWS_REGION"
+EOF
+}
+
+cmd_status() {
+    if [[ ! -f "$STATE_FILE" ]]; then
+        echo "not set up (no state file at $STATE_FILE)"
+        return
+    fi
+    load_state
+    echo "USER_POOL_ID=$USER_POOL_ID"
+    echo "CLIENT_ID=$CLIENT_ID"
+    echo "OIDC_PROVIDER_ARN=$OIDC_PROVIDER_ARN"
+    echo "ROLE_ARN=$ROLE_ARN"
+    echo "TOKEN_FILE=$TOKEN_FILE ($([[ -f $TOKEN_FILE ]] && echo present || echo missing))"
+}
+
+cmd_cleanup() {
+    require aws
+    if [[ ! -f "$STATE_FILE" ]]; then
+        log "no state at $STATE_FILE — nothing to clean up"
+        return 0
+    fi
+    load_state
+
+    # cleanup is tolerant of partial state (already-deleted resources, etc.)
+    set +e
+    set +o pipefail
+
+    log "detaching any role policies"
+    local attached
+    attached=$(aws iam list-attached-role-policies --role-name "$ROLE_NAME" \
+        --query 'AttachedPolicies[].PolicyArn' --output text 2>/dev/null)
+    for arn in $attached; do
+        log "  detaching $arn"
+        aws iam detach-role-policy --role-name "$ROLE_NAME" --policy-arn "$arn"
+    done
+
+    log "deleting IAM role $ROLE_NAME"
+    aws iam delete-role --role-name "$ROLE_NAME" 2>/dev/null
+
+    log "deleting IAM OIDC provider"
+    aws iam delete-open-id-connect-provider \
+        --open-id-connect-provider-arn "$OIDC_PROVIDER_ARN" 2>/dev/null
+
+    log "deleting Cognito user pool $USER_POOL_ID"
+    aws cognito-idp delete-user-pool \
+        --region "$AWS_REGION" \
+        --user-pool-id "$USER_POOL_ID" 2>/dev/null
+
+    rm -f "$TOKEN_FILE" "$TRUST_POLICY_FILE" "$STATE_FILE"
+    log "cleanup complete"
+}
+
+case "${1:-}" in
+    setup)   cmd_setup ;;
+    token)   cmd_token ;;
+    verify)  cmd_verify ;;
+    env)     cmd_env ;;
+    status)  cmd_status ;;
+    cleanup) cmd_cleanup ;;
+    *)
+        cat <<USAGE
+duckdb-oidc-test.sh — OIDC test harness for duckdb-aws PR #136
+
+USAGE: $0 <command>
+
+  setup    Create Cognito + IAM OIDC + IAM role, mint token, verify
+  token    Mint a fresh OIDC ID token (Cognito tokens expire after ~1h)
+  verify   Call sts:AssumeRoleWithWebIdentity to confirm trust chain
+  env      Print export lines for AWS_ROLE_ARN / AWS_WEB_IDENTITY_TOKEN_FILE
+  status   Show current state
+  cleanup  Tear down all AWS resources and remove state
+
+ENV (defaults shown):
+  AWS_REGION=us-east-1
+  POOL_NAME=duckdb-irsa-test
+  USERNAME=tester
+  PASSWORD=TestPassword123!
+  ROLE_NAME=duckdb-irsa-test-role
+  TOKEN_FILE=/tmp/duckdb-oidc-test-token
+  STATE_FILE=~/.duckdb-oidc-test.state
+
+TYPICAL FLOW:
+  $0 setup
+  eval "\$($0 env)"
+  # ... run duckdb-aws web_identity test ...
+  $0 cleanup
+USAGE
+        exit 1
+        ;;
+esac

--- a/src/aws_extension.cpp
+++ b/src/aws_extension.cpp
@@ -153,5 +153,4 @@ extern "C" {
 DUCKDB_CPP_EXTENSION_ENTRY(aws, loader) {
 	duckdb::LoadInternal(loader);
 }
-
 }

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -44,9 +44,8 @@ static struct {
 
 //! Parse and set the remaining options
 static void ParseCoreS3Config(CreateSecretInput &input, KeyValueSecret &secret) {
-	vector<string> options = {"key_id",   "secret",        "region",
-	                          "endpoint", "session_token", "url_style",
-	                          "use_ssl",  "s3_url_compatibility_mode"};
+	vector<string> options = {"key_id",        "secret",    "region",  "endpoint",
+	                          "session_token", "url_style", "use_ssl", "s3_url_compatibility_mode"};
 	for (const auto &val : options) {
 		auto set_region_param = input.options.find(val);
 		if (set_region_param != input.options.end()) {
@@ -122,6 +121,8 @@ public:
 				/* Credentials provider implementation that loads credentials from the Amazon EC2 Instance Metadata
 				 * Service. */
 				AddProvider(std::make_shared<Aws::Auth::InstanceProfileCredentialsProvider>());
+			} else if (item == "web_identity") {
+				AddProvider(std::make_shared<Aws::Auth::STSAssumeRoleWebIdentityCredentialsProvider>());
 			} else if (item == "process") {
 				if (profile.empty()) {
 					AddProvider(std::make_shared<Aws::Auth::ProcessCredentialsProvider>());
@@ -200,7 +201,8 @@ static string ConstructErrorMessage(string chain, string profile, string assume_
 	// these chains "generate" new aws keys. See their documentation in the header file
 	// https://github.com/aws/aws-sdk-cpp/blob/main/src/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentialsProvider.h
 	// if a roll is assumed, secrets are also "generated"
-	if (chain == "sts" || chain == "sso" || chain == "instance" || chain == "process" || !assume_role.empty()) {
+	if (chain == "sts" || chain == "sso" || chain == "instance" || chain == "process" || chain == "web_identity" ||
+	    !assume_role.empty()) {
 		verb = "generate";
 	}
 	string prefix = StringUtil::Format("Secret Validation Failure: during `%s` using the following:\n", verb);
@@ -299,7 +301,7 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 
 	// We have sneaked in this special handling where if you set the STS chain, you automatically enable refresh
 	// TODO: remove this once refresh is set to auto by default for all credential_chain provider created secrets.
-	if (chain == "sts" && refresh.empty()) {
+	if ((chain == "sts" || chain == "web_identity") && refresh.empty()) {
 		refresh = "auto";
 	}
 

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -92,7 +92,9 @@ class DuckDBCustomAWSCredentialsProviderChain : public Aws::Auth::AWSCredentials
 public:
 	explicit DuckDBCustomAWSCredentialsProviderChain(const string &credential_chain, const bool require_credentials,
 	                                                 const string &profile = "", const string &assume_role_arn = "",
-	                                                 const string &external_id = "") {
+	                                                 const string &external_id = "",
+	                                                 const string &web_identity_token_file = "",
+	                                                 const string &session_name = "") {
 		auto chain_list = StringUtil::Split(credential_chain, ';');
 
 		for (const auto &item : chain_list) {
@@ -122,7 +124,17 @@ public:
 				 * Service. */
 				AddProvider(std::make_shared<Aws::Auth::InstanceProfileCredentialsProvider>());
 			} else if (item == "web_identity") {
-				AddProvider(std::make_shared<Aws::Auth::STSAssumeRoleWebIdentityCredentialsProvider>());
+				Aws::Client::ClientConfiguration::CredentialProviderConfiguration config;
+				if (!assume_role_arn.empty()) {
+					config.stsCredentialsProviderConfig.roleArn = assume_role_arn;
+				}
+				if (!web_identity_token_file.empty()) {
+					config.stsCredentialsProviderConfig.tokenFilePath = web_identity_token_file;
+				}
+				if (!session_name.empty()) {
+					config.stsCredentialsProviderConfig.sessionName = session_name;
+				}
+				AddProvider(std::make_shared<Aws::Auth::STSAssumeRoleWebIdentityCredentialsProvider>(config));
 			} else if (item == "process") {
 				if (profile.empty()) {
 					AddProvider(std::make_shared<Aws::Auth::ProcessCredentialsProvider>());
@@ -196,7 +208,8 @@ static string TryGetStringParam(CreateSecretInput &input, const string &param_na
 	}
 }
 
-static string ConstructErrorMessage(string chain, string profile, string assume_role, string external_id) {
+static string ConstructErrorMessage(string chain, string profile, string assume_role, string external_id,
+                                    string web_identity_token_file, string session_name) {
 	string verb = "create";
 	// these chains "generate" new aws keys. See their documentation in the header file
 	// https://github.com/aws/aws-sdk-cpp/blob/main/src/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentialsProvider.h
@@ -210,6 +223,10 @@ static string ConstructErrorMessage(string chain, string profile, string assume_
 	prefix = chain.empty() ? prefix : prefix + StringUtil::Format("Credential Chain: '%s'\n", chain);
 	prefix = assume_role.empty() ? prefix : prefix + StringUtil::Format("Role-arn: '%s'\n", assume_role);
 	prefix = external_id.empty() ? prefix : prefix + StringUtil::Format("External-id: '%s'\n", external_id);
+	prefix = web_identity_token_file.empty()
+	             ? prefix
+	             : prefix + StringUtil::Format("Web Identity Token File: '%s'\n", web_identity_token_file);
+	prefix = session_name.empty() ? prefix : prefix + StringUtil::Format("Session Name: '%s'\n", session_name);
 	return prefix;
 }
 
@@ -221,6 +238,8 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 	string assume_role = TryGetStringParam(input, "assume_role_arn");
 	string external_id = TryGetStringParam(input, "external_id");
 	string chain = TryGetStringParam(input, "chain");
+	string web_identity_token_file = TryGetStringParam(input, "web_identity_token_file");
+	string session_name = TryGetStringParam(input, "session_name");
 	string validation = StringUtil::Lower(TryGetStringParam(input, "validation"));
 
 	if (!assume_role.empty() && chain.empty()) {
@@ -238,7 +257,8 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 	}
 
 	if (!chain.empty()) {
-		DuckDBCustomAWSCredentialsProviderChain provider(chain, require_credentials, profile, assume_role, external_id);
+		DuckDBCustomAWSCredentialsProviderChain provider(chain, require_credentials, profile, assume_role, external_id,
+		                                                 web_identity_token_file, session_name);
 		credentials = provider.GetAWSCredentials();
 	} else {
 		if (input.options.find("profile") != input.options.end()) {
@@ -262,7 +282,8 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 	}
 
 	if (credentials.IsEmpty() && require_credentials) {
-		throw InvalidConfigurationException(ConstructErrorMessage(chain, profile, assume_role, external_id));
+		throw InvalidConfigurationException(
+		    ConstructErrorMessage(chain, profile, assume_role, external_id, web_identity_token_file, session_name));
 	}
 
 	//! If the profile is set we specify a specific profile
@@ -381,6 +402,8 @@ void CreateAwsSecretFunctions::Register(ExtensionLoader &loader) {
 
 		cred_chain_function.named_parameters["assume_role_arn"] = LogicalType::VARCHAR;
 		cred_chain_function.named_parameters["external_id"] = LogicalType::VARCHAR;
+		cred_chain_function.named_parameters["web_identity_token_file"] = LogicalType::VARCHAR;
+		cred_chain_function.named_parameters["session_name"] = LogicalType::VARCHAR;
 
 		cred_chain_function.named_parameters["refresh"] = LogicalType::VARCHAR;
 

--- a/test/sql/aws_secret_chains.test
+++ b/test/sql/aws_secret_chains.test
@@ -103,3 +103,23 @@ CREATE SECRET env_secret (
     CHAIN 'env',
 	VALIDATION 'none'
 );
+
+# web_identity chain without env vars should fail validation
+statement error
+CREATE SECRET web_identity_secret (
+    TYPE S3,
+    PROVIDER credential_chain,
+    CHAIN 'web_identity'
+);
+----
+<REGEX>:.*Invalid Configuration Error: Secret Validation Failure: during `generate` using the following:
+Credential Chain: 'web_identity'.*
+
+# same as above, !validation
+statement ok
+CREATE SECRET web_identity_secret (
+    TYPE S3,
+    PROVIDER credential_chain,
+    CHAIN 'web_identity',
+	VALIDATION 'none'
+);

--- a/test/sql/aws_secret_validation.test
+++ b/test/sql/aws_secret_validation.test
@@ -1,4 +1,4 @@
-# name: test/sql/settings/aws_secret_validation_present.test
+# name: test/sql/aws_secret_validation.test
 # description: Test that SET secret_validation works
 # group: [sql]
 

--- a/test/sql/env/aws_secret_web_identity_env.test
+++ b/test/sql/env/aws_secret_web_identity_env.test
@@ -6,6 +6,8 @@ require aws
 
 require httpfs
 
+# This file can be tested using setup/teardown in scripts/duckdb-oidc-test.sh
+
 require-env AWS_ROLE_ARN
 
 require-env AWS_WEB_IDENTITY_TOKEN_FILE
@@ -13,7 +15,51 @@ require-env AWS_WEB_IDENTITY_TOKEN_FILE
 statement ok
 set secret_directory='__TEST_DIR__/aws_secret_web_identity_env'
 
-# web_identity chain should resolve credentials when IRSA env vars are present
+
+# invalid web identity token file passed
+statement error
+CREATE SECRET web_identity_test (
+    TYPE S3,
+    PROVIDER credential_chain,
+    ASSUME_ROLE_ARN 'arn:aws:iam::984506134640:role/duckdb-irsa-test-role',
+    WEB_IDENTITY_TOKEN_FILE 'blah/blah',
+    CHAIN 'web_identity'
+);
+----
+<REGEX>:.*Invalid Configuration Error: Secret Validation Failure: during `generate` using the following.*
+
+# invalid role
+statement error
+CREATE SECRET web_identity_test (
+    TYPE S3,
+    PROVIDER credential_chain,
+    ASSUME_ROLE_ARN 'arn:aws:iam::123456789123:role/invalid',
+    CHAIN 'web_identity'
+);
+----
+<REGEX>:.*Invalid Configuration Error: Secret Validation Failure: during `generate` using the following.*
+
+# # web_identity chain should resolve credentials when IRSA env vars are present
+statement ok
+CREATE SECRET web_identity_test (
+    TYPE S3,
+    PROVIDER credential_chain,
+    assume_role_arn 'arn:aws:iam::984506134640:role/duckdb-irsa-test-role',
+    WEB_IDENTITY_TOKEN_FILE '/tmp/duckdb-oidc-test-token',
+    CHAIN 'web_identity'
+);
+
+statement ok
+DROP SECRET web_identity_test;
+
+
+# no more secrets
+query I
+select count(*) from duckdb_secrets();
+----
+0
+
+# using environment variables also works
 statement ok
 CREATE SECRET web_identity_test (
     TYPE S3,

--- a/test/sql/env/aws_secret_web_identity_env.test
+++ b/test/sql/env/aws_secret_web_identity_env.test
@@ -1,0 +1,39 @@
+# name: test/sql/env/aws_secret_web_identity_env.test
+# description: test web_identity chain with IRSA env vars
+# group: [env]
+
+require aws
+
+require httpfs
+
+require-env AWS_ROLE_ARN
+
+require-env AWS_WEB_IDENTITY_TOKEN_FILE
+
+statement ok
+set secret_directory='__TEST_DIR__/aws_secret_web_identity_env'
+
+# web_identity chain should resolve credentials when IRSA env vars are present
+statement ok
+CREATE SECRET web_identity_test (
+    TYPE S3,
+    PROVIDER credential_chain,
+    CHAIN 'web_identity'
+);
+
+# credentials should be non-empty
+query I
+SELECT secret_string FROM duckdb_secrets(redact=false) where name='web_identity_test';
+----
+<REGEX>:.*key_id=.*
+
+query I
+SELECT secret_string FROM duckdb_secrets(redact=false) where name='web_identity_test';
+----
+<REGEX>:.*session_token=.*
+
+# auto-refresh should be enabled by default for web_identity
+query I
+SELECT secret_string FROM duckdb_secrets(redact=false) where name='web_identity_test';
+----
+<REGEX>:.*refresh_info=.*


### PR DESCRIPTION
Adds a `web_identity` credential chain that uses
`STSAssumeRoleWebIdentityCredentialsProvider` to support IAM Roles for Service Accounts (IRSA) in EKS.

The no-arg constructor reads `AWS_ROLE_ARN`,
`AWS_WEB_IDENTITY_TOKEN_FILE`, and `AWS_ROLE_SESSION_NAME` from environment variables. Auto-refresh is enabled by default since these are temporary STS credentials.

Fixes #119, fixes #93, fixes #31

note: automatic refresh only works on un-globbed s3 access https://github.com/duckdb/duckdb-httpfs/pull/165 
note2: auto-refresh doesn't work with Ducklake or Iceberg at all: https://github.com/duckdb/duckdb-httpfs/pull/165#issuecomment-4387317375