### PR TITLE
Fix region resolution to eliminate EC2 metadata calls and eliminate secret creation delay

### DIFF
--- a/src/aws_extension.cpp
+++ b/src/aws_extension.cpp
@@ -117,6 +117,7 @@ static void LoadAWSCredentialsFun(ClientContext &context, TableFunctionInput &da
 }
 static void LoadInternal(ExtensionLoader &loader) {
 	Aws::SDKOptions options;
+	setenv("AWS_EC2_METADATA_DISABLED", "true", 0);
 	Aws::InitAPI(options);
 
 	CreateAwsSecretFunctions::InitializeCurlCertificates(loader.GetDatabaseInstance());

--- a/src/aws_extension.cpp
+++ b/src/aws_extension.cpp
@@ -117,7 +117,6 @@ static void LoadAWSCredentialsFun(ClientContext &context, TableFunctionInput &da
 }
 static void LoadInternal(ExtensionLoader &loader) {
 	Aws::SDKOptions options;
-	setenv("AWS_EC2_METADATA_DISABLED", "true", 0);
 	Aws::InitAPI(options);
 
 	CreateAwsSecretFunctions::InitializeCurlCertificates(loader.GetDatabaseInstance());
@@ -154,5 +153,4 @@ extern "C" {
 DUCKDB_CPP_EXTENSION_ENTRY(aws, loader) {
 	duckdb::LoadInternal(loader);
 }
-
 }

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -242,20 +242,20 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 		region = region_param->second.ToString();
 	}
 
+	// or from DuckDB settings (SET s3_region='us-east-1')
+	if (region.empty()) {
+		Value s3_region_setting;
+		if (context.TryGetCurrentSetting("s3_region", s3_region_setting)) {
+			region = s3_region_setting.ToString();
+		}
+	}
+
 	// or from environment variables
 	if (region.empty()) {
 		if (const char *env = getenv("AWS_REGION")) {
 			region = env;
 		} else if (const char *env = getenv("AWS_DEFAULT_REGION")) {
 			region = env;
-		}
-	}
-
-	// or from DuckDB settings (SET s3_region='us-east-1')
-	if (region.empty()) {
-		Value s3_region_setting;
-		if (context.TryGetCurrentSetting("s3_region", s3_region_setting)) {
-			region = s3_region_setting.ToString();
 		}
 	}
 

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -251,6 +251,14 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 		}
 	}
 
+	// or from DuckDB settings (SET s3_region='us-east-1')
+	if (region.empty()) {
+		Value s3_region_setting;
+		if (context.TryGetCurrentSetting("s3_region", s3_region_setting)) {
+			region = s3_region_setting.ToString();
+		}
+	}
+
 	// or from AWS config profile
 	if (region.empty()) {
 		string profile_to_lookup = profile.empty() ? "default" : profile;

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -259,11 +259,14 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 	}
 
 	if (region.empty()) {
-		throw InvalidConfigurationException(
-		    "No AWS region found. Please specify a region explicitly in your secret using REGION 'us-east-1', "
-		    "or set the AWS_REGION environment variable, "
-		    "or add 'region' to your AWS config file profile '%s'.",
-		    profile.empty() ? "default" : profile);
+		DUCKDB_LOG_WARNING(context,
+		                   "No AWS region found for profile '%s'. "
+		                   "The SDK will default to us-east-1 and may contact EC2 Instance Metadata Service, "
+		                   "causing potential delays on non-EC2 machines. "
+		                   "Set region explicitly using REGION 'us-east-1', the AWS_REGION (or AWS_DEFAULT_REGION) "
+		                   "environment variable, "
+		                   "or add 'region' to your AWS config file.",
+		                   profile.empty() ? "default" : profile.c_str());
 	}
 
 	if (!chain.empty()) {

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -259,14 +259,10 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 	}
 
 	if (region.empty()) {
-		DUCKDB_LOG_WARNING(context,
-		                   "No AWS region found for profile '%s'. "
-		                   "The SDK will default to us-east-1 and may contact EC2 Instance Metadata Service, "
-		                   "causing potential delays on non-EC2 machines. "
-		                   "Set region explicitly using REGION 'us-east-1', the AWS_REGION (or AWS_DEFAULT_REGION) "
-		                   "environment variable, "
-		                   "or add 'region' to your AWS config file.",
-		                   profile.empty() ? "default" : profile.c_str());
+		DUCKDB_LOG_WARNING(
+		    context,
+		    "Set region explicitly using REGION 'us-east-1' in your CREATE SECRET statement, adding a region to your "
+		    "profile in ~/.aws/config or configure the AWS_REGION or AWS_DEFAULT_REGION environment variables.")
 	}
 
 	if (!chain.empty()) {
@@ -296,9 +292,6 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 	if (credentials.IsEmpty() && require_credentials) {
 		throw InvalidConfigurationException(ConstructErrorMessage(chain, profile, assume_role, external_id));
 	}
-
-	//! If the profile is set we specify a specific profile
-	auto s3_config = Aws::Client::ClientConfiguration(profile.c_str());
 
 	// TODO: We would also like to get the endpoint here, but it's currently not supported byq the AWS SDK:
 	// 		 https://github.com/aws/aws-sdk-cpp/issues/2587

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -44,9 +44,8 @@ static struct {
 
 //! Parse and set the remaining options
 static void ParseCoreS3Config(CreateSecretInput &input, KeyValueSecret &secret) {
-	vector<string> options = {"key_id",   "secret",        "region",
-	                          "endpoint", "session_token", "url_style",
-	                          "use_ssl",  "s3_url_compatibility_mode"};
+	vector<string> options = {"key_id",        "secret",    "region",  "endpoint",
+	                          "session_token", "url_style", "use_ssl", "s3_url_compatibility_mode"};
 	for (const auto &val : options) {
 		auto set_region_param = input.options.find(val);
 		if (set_region_param != input.options.end()) {
@@ -121,9 +120,7 @@ public:
 			} else if (item == "instance") {
 				/* Credentials provider implementation that loads credentials from the Amazon EC2 Instance Metadata
 				 * Service. */
-				setenv("AWS_EC2_METADATA_DISABLED", "false", 0);
 				AddProvider(std::make_shared<Aws::Auth::InstanceProfileCredentialsProvider>());
-				setenv("AWS_EC2_METADATA_DISABLED", "true", 0);
 			} else if (item == "process") {
 				if (profile.empty()) {
 					AddProvider(std::make_shared<Aws::Auth::ProcessCredentialsProvider>());
@@ -237,6 +234,40 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 		}
 	}
 
+	// Region MUST be set according to the SDK https://docs.aws.amazon.com/sdkref/latest/guide/feature-region.html
+	string region;
+	// Get region from secret options
+	auto region_param = input.options.find("region");
+	if (region_param != input.options.end() && !region_param->second.ToString().empty()) {
+		region = region_param->second.ToString();
+	}
+
+	// or from environment variables
+	if (region.empty()) {
+		if (const char *env = getenv("AWS_REGION")) {
+			region = env;
+		} else if (const char *env = getenv("AWS_DEFAULT_REGION")) {
+			region = env;
+		}
+	}
+
+	// or from AWS config profile
+	if (region.empty()) {
+		string profile_to_lookup = profile.empty() ? "default" : profile;
+		auto aws_profile = GetProfile(profile_to_lookup, false);
+		region = aws_profile.GetRegion();
+	}
+
+	if (region.empty()) {
+		throw InvalidConfigurationException(
+		    "No AWS region found. Please specify a region explicitly in your secret using REGION 'us-east-1', "
+		    "or set the AWS_REGION environment variable, "
+		    "or add 'region' to your AWS config file profile '%s'.",
+		    profile.empty() ? "default" : profile);
+	}
+
+	setenv("AWS_DEFAULT_REGION", region.c_str(), 1);
+
 	if (!chain.empty()) {
 		DuckDBCustomAWSCredentialsProviderChain provider(chain, require_credentials, profile, assume_role, external_id);
 		credentials = provider.GetAWSCredentials();
@@ -267,7 +298,6 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 
 	//! If the profile is set we specify a specific profile
 	auto s3_config = Aws::Client::ClientConfiguration(profile.c_str());
-	auto region = s3_config.region;
 
 	// TODO: We would also like to get the endpoint here, but it's currently not supported byq the AWS SDK:
 	// 		 https://github.com/aws/aws-sdk-cpp/issues/2587
@@ -291,10 +321,6 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 	}
 
 	auto result = ConstructBaseS3Secret(scope, input.type, input.provider, input.name);
-
-	if (!region.empty()) {
-		result->secret_map["region"] = region;
-	}
 
 	// Only auto is supported
 	string refresh = TryGetStringParam(input, "refresh");

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -266,8 +266,6 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 		    profile.empty() ? "default" : profile);
 	}
 
-	setenv("AWS_DEFAULT_REGION", region.c_str(), 1);
-
 	if (!chain.empty()) {
 		DuckDBCustomAWSCredentialsProviderChain provider(chain, require_credentials, profile, assume_role, external_id);
 		credentials = provider.GetAWSCredentials();
@@ -321,6 +319,10 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 	}
 
 	auto result = ConstructBaseS3Secret(scope, input.type, input.provider, input.name);
+
+	if (!region.empty()) {
+		result->secret_map["region"] = region;
+	}
 
 	// Only auto is supported
 	string refresh = TryGetStringParam(input, "refresh");

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -121,7 +121,9 @@ public:
 			} else if (item == "instance") {
 				/* Credentials provider implementation that loads credentials from the Amazon EC2 Instance Metadata
 				 * Service. */
+				setenv("AWS_EC2_METADATA_DISABLED", "false", 0);
 				AddProvider(std::make_shared<Aws::Auth::InstanceProfileCredentialsProvider>());
+				setenv("AWS_EC2_METADATA_DISABLED", "true", 0);
 			} else if (item == "process") {
 				if (profile.empty()) {
 					AddProvider(std::make_shared<Aws::Auth::ProcessCredentialsProvider>());

--- a/test/sql/aws_secret_region_warning.test
+++ b/test/sql/aws_secret_region_warning.test
@@ -51,6 +51,7 @@ statement ok
 CREATE OR REPLACE SECRET no_region_secret (
     TYPE S3,
     PROVIDER credential_chain,
+    PROFILE 'profile_that_does_not_exist',
     VALIDATION 'none'
 );
 

--- a/test/sql/aws_secret_region_warning.test
+++ b/test/sql/aws_secret_region_warning.test
@@ -1,0 +1,63 @@
+# name: test/sql/aws_secret_region_warning.test
+# description: test that a warning is triggered when no region is set, and not triggered when it is set
+# group: [sql]
+
+require aws
+
+require httpfs
+
+statement ok
+CALL enable_logging(level='warning');
+
+# When REGION is set explicitly in the statement, no warning should be triggered
+statement ok
+CREATE OR REPLACE SECRET explicit_region_secret (
+    TYPE S3,
+    PROVIDER credential_chain,
+    REGION 'us-east-1',
+    VALIDATION 'none'
+);
+
+query II
+SELECT log_level, message FROM duckdb_logs WHERE message LIKE '%region%'
+----
+
+statement ok
+CALL truncate_duckdb_logs();
+
+# When s3_region is set via SET, no warning should be triggered
+statement ok
+SET s3_region='us-east-1';
+
+statement ok
+CREATE OR REPLACE SECRET set_region_secret (
+    TYPE S3,
+    PROVIDER credential_chain,
+    VALIDATION 'none'
+);
+
+query II
+SELECT log_level, message FROM duckdb_logs WHERE message LIKE '%region%'
+----
+
+statement ok
+CALL truncate_duckdb_logs();
+
+statement ok
+SET s3_region='';
+
+# When no region is set anywhere, creating a secret should trigger a warning
+statement ok
+CREATE OR REPLACE SECRET no_region_secret (
+    TYPE S3,
+    PROVIDER credential_chain,
+    VALIDATION 'none'
+);
+
+query II
+SELECT log_level, message FROM duckdb_logs WHERE message LIKE '%region%'
+----
+WARNING	Set region explicitly using REGION 'us-east-1' in your CREATE SECRET statement, adding a region to your profile in ~/.aws/config or configure the AWS_REGION or AWS_DEFAULT_REGION environment variables.
+
+statement ok
+CALL truncate_duckdb_logs();

--- a/test/sql/aws_secret_validation.test
+++ b/test/sql/aws_secret_validation.test
@@ -1,4 +1,4 @@
-# name: test/sql/settings/aws_secret_validation_present.test
+# name: test/sql/aws_secret_validation.test
 # description: Test that SET secret_validation works
 # group: [sql]
 


### PR DESCRIPTION
## What was happening:

When creating a secret in AWS, it sometimes took around 5 seconds due to the AWS SDK attempting to resolve the AWS region by querying the EC2 Instance Metadata Service (IMDS). This service is only available on EC2 instances, so when running on non-EC2 machines, the SDK couldn’t reach the endpoint. As a result, the SDK made multiple HTTP requests (up to 5), each timing out after approximately 1 second before giving up, which caused the delay.

## What's changed:

The AWS SDK documentation is [explicit](https://docs.aws.amazon.com/sdkref/latest/guide/feature-region.html) that the region has no default value and must be specified in one of the following locations:
- Explicitly in the secret statement (e.g., `REGION 'us-east-1'`)
- As an environment variable (`AWS_REGION` or `AWS_DEFAULT_REGION`)
- In the AWS config file (`~/.aws/config`)

Previously, the code built the credential provider chain before resolving the region, which caused the SDK to fall back to IMDS when the region wasn't specified. To address this, we now resolve the region first, checking all three locations in order of precedence. If the region cannot be found in any of these locations, an explicit error is thrown, preventing silent failures and eliminating unnecessary IMDS calls. This change ensures that the region requirement is clear to the user and avoids the unnecessary network overhead.