### PR TITLE
Add RDS secret type for IAM auth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES})
 # Weirdly we need to manually to this, otherwise linking against
 # ${AWSSDK_LINK_LIBRARIES} fails for some reason
 find_package(ZLIB REQUIRED)
-find_package(AWSSDK REQUIRED COMPONENTS core sso sts identity-management)
+find_package(AWSSDK REQUIRED COMPONENTS core sso sts identity-management rds)
 
 # Build static lib
 target_include_directories(${EXTENSION_NAME}

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -12,6 +12,7 @@
 #include <aws/core/config/AWSConfigFileProfileConfigLoader.h>
 #include <aws/core/config/AWSProfileConfigLoaderBase.h>
 #include <aws/identity-management/auth/STSAssumeRoleCredentialsProvider.h>
+#include <aws/rds/RDSClient.h>
 #include <aws/sts/STSClient.h>
 
 #include <sys/stat.h>
@@ -230,6 +231,73 @@ static string ConstructErrorMessage(string chain, string profile, string assume_
 	return prefix;
 }
 
+static string GenerateRDSSecretToken(std::shared_ptr<DuckDBCustomAWSCredentialsProviderChain> &provider,
+                                     const string &user, const string &host, const string &port, const string &region) {
+	Aws::Client::ClientConfiguration config;
+	config.region = region;
+	Aws::RDS::RDSClient rds_client(provider, config);
+
+	// https://github.com/aws/aws-sdk-cpp/issues/861#issuecomment-386643571
+	// Aws::String token = rdsClient.GenerateConnectAuthToken(hostname.c_str(), aws_region.c_str(),
+	// static_cast<unsigned>(port_int), username.c_str());
+
+	uint64_t expiration_seconds = 900; // 15 min, this value is fixed, also used on consumer side
+	string host_and_port = host + ":" + port;
+	string host_and_port_with_prefix = "http://" + host_and_port;
+	string host_and_port_with_suffix = host_and_port + "/";
+	Aws::Http::URI uri(host_and_port_with_prefix.c_str());
+	uri.AddQueryStringParameter("Action", "connect");
+	uri.AddQueryStringParameter("DBUser", user.c_str());
+	auto token = rds_client.GeneratePresignedUrl(uri, Aws::Http::HttpMethod::HTTP_GET, region.c_str(), "rds-db",
+	                                             static_cast<long long>(expiration_seconds));
+	Aws::Utils::StringUtils::Replace(token, host_and_port_with_prefix.c_str(), host_and_port_with_suffix.c_str());
+
+	return string(token.c_str());
+}
+
+static unique_ptr<BaseSecret>
+CreateRDSSecretWithProvider(std::shared_ptr<DuckDBCustomAWSCredentialsProviderChain> &provider,
+                            CreateSecretInput &input, const string &region) {
+	string user = TryGetStringParam(input, "rds_user");
+	string host = TryGetStringParam(input, "rds_host");
+	string port = TryGetStringParam(input, "rds_port");
+	if (user.empty() || host.empty() || port.empty() || region.empty()) {
+		throw InvalidInputException(
+		    "Invalid RDS secret parameters, 'RDS_USER', 'RDS_HOST', 'RDS_PORT' and 'REGION' options must be specified");
+	}
+
+	vector<string> scope;
+	auto result = ConstructBaseS3Secret(scope, input.type, input.provider, input.name);
+
+	string template_secret_name = TryGetStringParam(input, "rds_template_secret_name");
+
+	// When user creates a SECRET of type "rds", resulting secret is a "template"
+	// that is used by duckdb-postgres to generate actual token. To effectively call
+	// 'CreateAWSSecretFromCredentialChain' duckdb-postgres recreated the secret with
+	// 'rds_template_secret_name' specified and reads its 'secret_token' field.
+	// To allow it to do so, we put all the input fields into the resulting "template"
+	// secret.
+	// TODO: RDS token refresh mechanics should be improved
+	bool generate_secret_token = !template_secret_name.empty();
+
+	if (!generate_secret_token) {
+		for (auto &en : input.options) {
+			result->secret_map[en.first] = en.second;
+		}
+		return result;
+	}
+
+	// "rds_template_secret_name" was specified when creting the secret,
+	// so we are generating and returning actual token in "session_token" field
+	string token = GenerateRDSSecretToken(provider, user, host, port, region);
+
+	// We do not throwing here if the resulting token was generated incorrectly,
+	// instead the consumer must do appropriate checks and report the error without
+	// including the whole input `CREATE SECRET` query into the error message.
+	result->secret_map["session_token"] = Value(token);
+	return result;
+}
+
 //! This is the actual callback function
 static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &context, CreateSecretInput &input) {
 	Aws::Auth::AWSCredentials credentials;
@@ -286,6 +354,16 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 		string profile_to_lookup = profile.empty() ? "default" : profile;
 		auto aws_profile = GetProfile(profile_to_lookup, false);
 		region = aws_profile.GetRegion();
+	}
+
+	if (input.type == "rds") {
+		if (chain.empty()) {
+			throw InvalidConfigurationException("Invalid RDS secret parameters, 'CHAIN' option must be specified");
+		}
+		auto provider = Aws::MakeShared<DuckDBCustomAWSCredentialsProviderChain>("rds", chain, require_credentials,
+		                                                                         profile, assume_role, external_id,
+		                                                                         web_identity_token_file, session_name);
+		return CreateRDSSecretWithProvider(provider, input, region);
 	}
 
 	if (region.empty()) {
@@ -419,7 +497,7 @@ void CreateAwsSecretFunctions::InitializeCurlCertificates(DatabaseInstance &db) 
 }
 
 void CreateAwsSecretFunctions::Register(ExtensionLoader &loader) {
-	vector<string> types = {"s3", "r2", "gcs", "aws"};
+	vector<string> types = {"s3", "r2", "gcs", "aws", "rds"};
 
 	for (const auto &type : types) {
 		// Register the credential_chain secret provider
@@ -444,6 +522,13 @@ void CreateAwsSecretFunctions::Register(ExtensionLoader &loader) {
 
 		if (type == "r2") {
 			cred_chain_function.named_parameters["account_id"] = LogicalType::VARCHAR;
+		}
+
+		if (type == "rds") {
+			cred_chain_function.named_parameters["rds_user"] = LogicalType::VARCHAR;
+			cred_chain_function.named_parameters["rds_host"] = LogicalType::VARCHAR;
+			cred_chain_function.named_parameters["rds_port"] = LogicalType::VARCHAR;
+			cred_chain_function.named_parameters["rds_template_secret_name"] = LogicalType::VARCHAR;
 		}
 
 		// Param for configuring the chain that is used

--- a/test/sql/aws_secret_rds.test
+++ b/test/sql/aws_secret_rds.test
@@ -1,0 +1,50 @@
+# name: test/sql/aws_secret_rds.test
+# description: test aws extension with rds secret
+# group: [sql]
+
+require aws
+
+require-env RDS_TEST_SERVER_AVAILABLE 1
+
+# Note not doing DB connection here, only checking that
+# the secret can be created and token can be obtained
+
+statement ok
+LOAD aws
+
+statement ok
+LOAD postgres
+
+statement ok
+SET allow_persistent_secrets=false
+
+statement ok
+CREATE SECRET rds_template_secret1 (
+    TYPE rds,
+    PROVIDER credential_chain,
+    CHAIN 'sso',
+    PROFILE 'DatabaseAdministrator-xxx',
+    REGION 'eu-west-1',
+    RDS_USER 'postgres',
+    RDS_HOST 'database-1-instance-1.xxxxxxxxxxxx.eu-west-1.rds.amazonaws.com',
+    RDS_PORT '5432'
+);
+
+statement ok
+CREATE SECRET rds_secret1 (
+    TYPE rds,
+    PROVIDER credential_chain,
+    CHAIN 'sso',
+    PROFILE 'DatabaseAdministrator-xxx',
+    REGION 'eu-west-1',
+    RDS_USER 'postgres',
+    RDS_HOST 'database-1-instance-1.xxxxxxxxxxxx.eu-west-1.rds.amazonaws.com',
+    RDS_PORT '5432',
+    RDS_TEMPLATE_SECRET_NAME rds_template_secret1
+);
+
+statement ok
+DROP SECRET rds_template_secret1
+
+statement ok
+DROP SECRET rds_secret1

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,7 +4,7 @@
     "zlib",
     {
       "name": "aws-sdk-cpp",
-      "features": [ "sso", "sts" , "identity-management"]
+      "features": [ "sso", "sts" , "identity-management", "rds"]
     },
     "openssl",
     "curl"


### PR DESCRIPTION
This PR adds support for secrets of type `rds` and implements the generation of IAM tokens to access AWS RDS databases.

Like with other secret types, the secret function for `credential_chain` provider is implemented and registered in `aws` extension, but the type itself is registered by the `postgres` extension.

RDS IAM tokens are short lived and required refreshing, the refresh logic is currently implemented on consumer ('postgres') side.

The change is expected to not affect any other types of secrets as all new code is guarded by secret type `rds` checks.

Testing: tested manually with AWS SSO auth and a default Aurora serverless instance.

Fixes: duckdb/duckdb-postgres#464