### PR TITLE
 Check allow_unredacted_secrets before exposing credentials

### DIFF
--- a/src/aws_extension.cpp
+++ b/src/aws_extension.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/main/settings.hpp"
 #include <duckdb/parser/parsed_data/create_scalar_function_info.hpp>
 #include <aws/core/Aws.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
@@ -69,6 +70,11 @@ static unique_ptr<FunctionData> LoadAWSCredentialsBind(ClientContext &context, T
 		}
 	}
 
+	if (!result->redact_secret && !Settings::Get<AllowUnredactedSecretsSetting>(context)) {
+		throw InvalidInputException("Displaying unredacted secrets is disabled: set allow_unredacted_secrets to true "
+		                            "at startup to enable this");
+	}
+
 	if (input.inputs.size() >= 1) {
 		result->profile_name = input.inputs[0].ToString();
 	}
@@ -108,7 +114,11 @@ static void LoadAWSCredentialsFun(ClientContext &context, TableFunctionInput &da
 		output.SetValue(1, 0,
 		                load_result.set_secret_access_key.empty() ? Value(nullptr) : load_result.set_secret_access_key);
 	}
-	output.SetValue(2, 0, load_result.set_session_token.empty() ? Value(nullptr) : load_result.set_session_token);
+	if (data.redact_secret && !load_result.set_session_token.empty()) {
+		output.SetValue(2, 0, "<redacted>");
+	} else {
+		output.SetValue(2, 0, load_result.set_session_token.empty() ? Value(nullptr) : load_result.set_session_token);
+	}
 	output.SetValue(3, 0, load_result.set_region.empty() ? Value(nullptr) : load_result.set_region);
 
 	output.SetCardinality(1);

--- a/src/aws_extension.cpp
+++ b/src/aws_extension.cpp
@@ -114,11 +114,7 @@ static void LoadAWSCredentialsFun(ClientContext &context, TableFunctionInput &da
 		output.SetValue(1, 0,
 		                load_result.set_secret_access_key.empty() ? Value(nullptr) : load_result.set_secret_access_key);
 	}
-	if (data.redact_secret && !load_result.set_session_token.empty()) {
-		output.SetValue(2, 0, "<redacted>");
-	} else {
-		output.SetValue(2, 0, load_result.set_session_token.empty() ? Value(nullptr) : load_result.set_session_token);
-	}
+	output.SetValue(2, 0, load_result.set_session_token.empty() ? Value(nullptr) : load_result.set_session_token);
 	output.SetValue(3, 0, load_result.set_region.empty() ? Value(nullptr) : load_result.set_region);
 
 	output.SetCardinality(1);

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -146,8 +146,7 @@ public:
 				if (profile.empty()) {
 					AddProvider(std::make_shared<Aws::Auth::SSOCredentialsProvider>(Aws::String(), sso_config));
 				} else {
-					AddProvider(
-					    std::make_shared<Aws::Auth::SSOCredentialsProvider>(profile.c_str(), sso_config));
+					AddProvider(std::make_shared<Aws::Auth::SSOCredentialsProvider>(profile.c_str(), sso_config));
 				}
 			} else if (item == "env") {
 				AddProvider(std::make_shared<Aws::Auth::EnvironmentAWSCredentialsProvider>());

--- a/test/sql/aws_secret_redaction.test
+++ b/test/sql/aws_secret_redaction.test
@@ -1,0 +1,27 @@
+# name: test/sql/aws_secret_redaction.test
+# description: Tests that load_aws_credentials respects allow_unredacted_secrets
+# group: [sql]
+
+require aws
+
+require httpfs
+
+statement ok
+CALL load_aws_credentials();
+
+statement ok
+CALL load_aws_credentials(redact_secret => true);
+
+statement ok
+CALL load_aws_credentials(redact_secret => false);
+
+statement ok
+SET allow_unredacted_secrets = false;
+
+statement error
+CALL load_aws_credentials(redact_secret => false);
+----
+Displaying unredacted secrets is disabled
+
+statement ok
+CALL load_aws_credentials();

--- a/test/sql/env/aws_env_var.test
+++ b/test/sql/env/aws_env_var.test
@@ -20,11 +20,11 @@ CALL load_aws_credentials();
 ----
 duckdb_env_testing_id	<redacted>	NULL	<REGEX>:.*
 
-# double check if secret is still redacted
+# allow_unredacted_secrets=true, redact_secret=false returns actual values
 query IIII
 CALL load_aws_credentials(redact_secret => false);
 ----
-duckdb_env_testing_id	<redacted>	NULL	<REGEX>:.*
+duckdb_env_testing_id	duckdb_env_testing_key	NULL	<REGEX>:.*
 
 query I
 select value from duckdb_settings() where name='s3_secret_access_key';

--- a/test/sql/env/aws_env_var.test
+++ b/test/sql/env/aws_env_var.test
@@ -14,8 +14,17 @@ require-env AWS_SECRET_ACCESS_KEY
 
 require-env AWS_DEFAULT_REGION
 
-statement ok
+# secret key and session token must appear as <redacted> in output
+query IIII
 CALL load_aws_credentials();
+----
+duckdb_env_testing_id	<redacted>	NULL	<REGEX>:.*
+
+# double check if secret is still redacted
+query IIII
+CALL load_aws_credentials(redact_secret => false);
+----
+duckdb_env_testing_id	<redacted>	NULL	<REGEX>:.*
 
 query I
 select value from duckdb_settings() where name='s3_secret_access_key';

--- a/test/sql/env/aws_env_var.test
+++ b/test/sql/env/aws_env_var.test
@@ -14,7 +14,7 @@ require-env AWS_SECRET_ACCESS_KEY
 
 require-env AWS_DEFAULT_REGION
 
-# secret key and session token must appear as <redacted> in output
+# secret key must appear as <redacted> in output; no session token in this env so NULL
 query IIII
 CALL load_aws_credentials();
 ----


### PR DESCRIPTION
Any user could bypass `allow_unredacted_secrets` simply by `CALL load_aws_credentials(redact_secret => false)`, causing credentials to be exposed. This PR fixes that by checking `allow_unredacted_secrets` before exposing credentials.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/9594