### PR TITLE
feat: store credential expiration epoch in secret for proactive refresh

### DIFF
--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -476,6 +476,13 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 		result->secret_map["key_id"] = Value(credentials.GetAWSAccessKeyId());
 		result->secret_map["secret"] = Value(credentials.GetAWSSecretKey());
 		result->secret_map["session_token"] = Value(credentials.GetSessionToken());
+
+		// Store credential expiration as epoch seconds so consumers (e.g., duckdb-iceberg)
+		// can refresh proactively at ~80% TTL instead of guessing with a fixed timer.
+		auto expiration = credentials.GetExpiration();
+		if (expiration != Aws::Utils::DateTime()) {
+			result->secret_map["expiration_epoch"] = Value::BIGINT(expiration.Seconds());
+		}
 	}
 
 	ParseCoreS3Config(input, *result);


### PR DESCRIPTION
## Problem

When the `credential_chain` provider creates a secret with `web_identity` or `sts` chains, the STS response includes an `Expiration` timestamp — but the extension only stores `key_id`, `secret`, and `session_token`. The expiration is discarded.

Consumers (e.g., duckdb-iceberg) that need to refresh credentials have no way to know when they expire, and must resort to fixed-interval timers (e.g., refresh every 300s regardless of actual TTL).

## Fix

Store `credentials.GetExpiration()` as `expiration_epoch` (epoch seconds as BIGINT) in the `secret_map` when the expiration is non-empty. This is backwards-compatible — existing consumers that don't read it are unaffected.

## Usage by consumers

```cpp
Value expiry_val;
if (kv_secret.TryGetValue("expiration_epoch", expiry_val)) {
    int64_t expires_at = expiry_val.GetValue<int64_t>();
    int64_t now = std::chrono::duration_cast<std::chrono::seconds>(
        std::chrono::system_clock::now().time_since_epoch()).count();
    int64_t ttl = expires_at - created_at;
    if ((expires_at - now) < ttl * 0.2) {
        // Refresh — less than 20% TTL remaining
    }
}
```

## Related

- [duckdb/duckdb-iceberg#1051](https://github.com/duckdb/duckdb-iceberg/pull/1051) — credential auto-refresh for Iceberg SIGV4 (will consume this field)