### PR TITLE
Bump duckdb submodule to origin/main

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: aws
-      duckdb_version: f0af2e1b4462143158289d5bb8028d52ee1f3342
+      duckdb_version: 2009475939c7b5ada2e55cc74843339bd9be79e3
       ci_tools_version: main
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw' # Doesn't work anyway: env local file or env access possible
 
@@ -28,7 +28,7 @@ jobs:
     secrets: inherit
     with:
       extension_name: aws
-      duckdb_version: f0af2e1b4462143158289d5bb8028d52ee1f3342
+      duckdb_version: 2009475939c7b5ada2e55cc74843339bd9be79e3
       ci_tools_version: main
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw' # Doesn't work anyway: env local file or env access possible
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -2,6 +2,7 @@
 #include "aws_client.hpp"
 
 #include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/logging/logger.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 


### PR DESCRIPTION
Move the duckdb submodule pin from f0af2e1 (#23401) up to current duckdb main (dfd8755084), 1461 commits forward.