### PR TITLE
Add quack-on-ec2, and add cloudformation list improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ endif()
 add_compile_definitions(DUCKDB_AWS_GIT_SHA="${DUCKDB_AWS_GIT_SHA}")
 
 set(EXTENSION_SOURCES src/aws_extension.cpp src/aws_secret.cpp src/cloudformation_functions.cpp
+                      src/quack_on_ec2_resource.cpp
                       src/redshift/redshift_utils.cpp src/redshift/redshift_storage.cpp
                       src/utils/utils.cpp)
 add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES})

--- a/src/aws_extension.cpp
+++ b/src/aws_extension.cpp
@@ -1,6 +1,7 @@
 #include "aws_secret.hpp"
 #include "aws_extension.hpp"
 #include "cloudformation_functions.hpp"
+#include "quack_on_ec2_resource.hpp"
 #include "redshift/redshift_utils.hpp"
 
 #include "duckdb.hpp"
@@ -26,6 +27,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	Redshift::RegisterStorageExtension(loader);
 
 	CloudFormationFunctions::Register(loader);
+	QuackOnEc2Resource::Register(loader);
 }
 
 void AwsExtension::Load(ExtensionLoader &loader) {

--- a/src/cloudformation_functions.cpp
+++ b/src/cloudformation_functions.cpp
@@ -866,8 +866,8 @@ static void CloudFormationListStacksFun(ClientContext &context, TableFunctionInp
 // (ec2:DescribeRegions / account:ListRegions) is the accuracy follow-up so newly-enabled opt-in regions are
 // not silently missed.
 static const char *const AWS_DEFAULT_REGIONS[] = {
-    "us-east-1",      "us-east-2",      "us-west-1",      "us-west-2",      "ca-central-1", "sa-east-1",
-    "eu-west-1",      "eu-west-2",      "eu-west-3",      "eu-central-1",   "eu-north-1",   "ap-south-1",
+    "us-east-1",      "us-east-2",      "us-west-1",      "us-west-2",      "ca-central-1",  "sa-east-1",
+    "eu-west-1",      "eu-west-2",      "eu-west-3",      "eu-central-1",   "eu-north-1",    "ap-south-1",
     "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-southeast-1", "ap-southeast-2"};
 
 struct CloudFormationDescribeStacksRow {
@@ -916,7 +916,8 @@ static void DescribeRegionStacks(const string &region, vector<CloudFormationDesc
 			row.status_reason = FromAws(stack.GetStackStatusReason());
 			row.creation_time = FromAws(stack.GetCreationTime().ToGmtString(Aws::Utils::DateFormat::ISO_8601));
 			if (stack.LastUpdatedTimeHasBeenSet()) {
-				row.last_updated_time = FromAws(stack.GetLastUpdatedTime().ToGmtString(Aws::Utils::DateFormat::ISO_8601));
+				row.last_updated_time =
+				    FromAws(stack.GetLastUpdatedTime().ToGmtString(Aws::Utils::DateFormat::ISO_8601));
 			}
 			row.description = FromAws(stack.GetDescription());
 
@@ -926,7 +927,8 @@ static void DescribeRegionStacks(const string &region, vector<CloudFormationDesc
 				tag_keys.emplace_back(FromAws(t.GetKey()));
 				tag_values.emplace_back(FromAws(t.GetValue()));
 			}
-			row.tags = Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, std::move(tag_keys), std::move(tag_values));
+			row.tags =
+			    Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, std::move(tag_keys), std::move(tag_values));
 
 			vector<Value> output_keys;
 			vector<Value> output_values;
@@ -1140,8 +1142,7 @@ void CloudFormationFunctions::Register(ExtensionLoader &loader) {
 	// Overloaded: no arg -> all default regions (parallel); VARCHAR -> one region; LIST(VARCHAR) -> those
 	// regions (parallel). Bind dispatches on the argument shape.
 	TableFunctionSet describe_all_set("cloudformation_describe_stacks");
-	describe_all_set.AddFunction(
-	    TableFunction({}, CloudFormationDescribeStacksFun, CloudFormationDescribeStacksBind));
+	describe_all_set.AddFunction(TableFunction({}, CloudFormationDescribeStacksFun, CloudFormationDescribeStacksBind));
 	describe_all_set.AddFunction(
 	    TableFunction({LogicalType::VARCHAR}, CloudFormationDescribeStacksFun, CloudFormationDescribeStacksBind));
 	describe_all_set.AddFunction(TableFunction({LogicalType::LIST(LogicalType::VARCHAR)},

--- a/src/cloudformation_functions.cpp
+++ b/src/cloudformation_functions.cpp
@@ -7,9 +7,11 @@
 #include "duckdb/common/insertion_order_preserving_map.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/uuid.hpp"
+#include "duckdb/function/function_set.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parallel/task_executor.hpp"
 
 #include <aws/cloudformation/CloudFormationClient.h>
 #include <aws/cloudformation/model/Capability.h>
@@ -847,6 +849,251 @@ static void CloudFormationListStacksFun(ClientContext &context, TableFunctionInp
 }
 
 //===--------------------------------------------------------------------===//
+// cloudformation_describe_stacks([region | region_list])
+//
+// DescribeStacks with no stack name: every stack in the region(s) (paginated),
+// carrying tags and outputs — the tag-and-output-bearing counterpart to the
+// tag-less cloudformation_list_stacks. DELETE_COMPLETE stacks are not returned.
+//
+// Three overloads: no argument sweeps all default regions in parallel; a single
+// VARCHAR is one region (its error is thrown); a LIST(VARCHAR) is those regions
+// in parallel. The parallel variants fan out one task per region over DuckDB's
+// scheduler and SKIP a region that errors (denied/unreachable) rather than
+// failing the whole sweep.
+//===--------------------------------------------------------------------===//
+
+// Default-enabled commercial regions swept by the no-argument overload. Hardcoded for now; live enumeration
+// (ec2:DescribeRegions / account:ListRegions) is the accuracy follow-up so newly-enabled opt-in regions are
+// not silently missed.
+static const char *const AWS_DEFAULT_REGIONS[] = {
+    "us-east-1",      "us-east-2",      "us-west-1",      "us-west-2",      "ca-central-1", "sa-east-1",
+    "eu-west-1",      "eu-west-2",      "eu-west-3",      "eu-central-1",   "eu-north-1",   "ap-south-1",
+    "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-southeast-1", "ap-southeast-2"};
+
+struct CloudFormationDescribeStacksRow {
+	string region;
+	string stack_name;
+	string stack_id;
+	string status;
+	string status_reason;
+	string creation_time;
+	string last_updated_time;
+	string description;
+	Value tags;
+	Value outputs;
+	// Empty for a real stack; the AWS error message for a failed-region sentinel row (region set, all stack
+	// columns NULL). Discriminates the two row kinds: real stacks have region_error IS NULL.
+	string region_error;
+};
+
+// Fetch all stacks in one region (paginated), appending to `out`. Throws on AWS error.
+static void DescribeRegionStacks(const string &region, vector<CloudFormationDescribeStacksRow> &out) {
+	auto provider = BuildAwsCredentialsProvider("", /*require_credentials=*/true);
+	auto cfg = BuildClientConfigWithCa();
+	cfg.region = region.c_str();
+	Aws::CloudFormation::CloudFormationClient cloudformation_client(provider, cfg);
+
+	Aws::String next_token;
+	do {
+		Aws::CloudFormation::Model::DescribeStacksRequest req;
+		if (!next_token.empty()) {
+			req.SetNextToken(next_token);
+		}
+		auto outcome = cloudformation_client.DescribeStacks(req);
+		if (!outcome.IsSuccess()) {
+			const auto &err = outcome.GetError();
+			throw IOException("CloudFormation DescribeStacks failed: %s - %s", FromAws(err.GetExceptionName()),
+			                  FromAws(err.GetMessage()));
+		}
+		const auto &res = outcome.GetResult();
+		for (const auto &stack : res.GetStacks()) {
+			CloudFormationDescribeStacksRow row;
+			row.region = region;
+			row.stack_name = FromAws(stack.GetStackName());
+			row.stack_id = FromAws(stack.GetStackId());
+			row.status =
+			    FromAws(Aws::CloudFormation::Model::StackStatusMapper::GetNameForStackStatus(stack.GetStackStatus()));
+			row.status_reason = FromAws(stack.GetStackStatusReason());
+			row.creation_time = FromAws(stack.GetCreationTime().ToGmtString(Aws::Utils::DateFormat::ISO_8601));
+			if (stack.LastUpdatedTimeHasBeenSet()) {
+				row.last_updated_time = FromAws(stack.GetLastUpdatedTime().ToGmtString(Aws::Utils::DateFormat::ISO_8601));
+			}
+			row.description = FromAws(stack.GetDescription());
+
+			vector<Value> tag_keys;
+			vector<Value> tag_values;
+			for (const auto &t : stack.GetTags()) {
+				tag_keys.emplace_back(FromAws(t.GetKey()));
+				tag_values.emplace_back(FromAws(t.GetValue()));
+			}
+			row.tags = Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, std::move(tag_keys), std::move(tag_values));
+
+			vector<Value> output_keys;
+			vector<Value> output_values;
+			for (const auto &o : stack.GetOutputs()) {
+				output_keys.emplace_back(FromAws(o.GetOutputKey()));
+				output_values.emplace_back(FromAws(o.GetOutputValue()));
+			}
+			row.outputs = Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, std::move(output_keys),
+			                         std::move(output_values));
+
+			out.push_back(std::move(row));
+		}
+		next_token = res.GetNextToken();
+	} while (!next_token.empty());
+}
+
+// One region's DescribeStacks as a scheduler task. Catches its own AWS error (never PushError, which would
+// abort the whole sweep via WorkOnTasks) and replaces its slot with a single 'region_error' sentinel row, so
+// a dead region is surfaced-but-not-fatal instead of silently vanishing.
+struct DescribeRegionTask : public BaseExecutorTask {
+	DescribeRegionTask(TaskExecutor &executor, string region_p, vector<CloudFormationDescribeStacksRow> &slot_p)
+	    : BaseExecutorTask(executor), region(std::move(region_p)), slot(slot_p) {
+	}
+	void ExecuteTask() override {
+		try {
+			DescribeRegionStacks(region, slot);
+		} catch (const std::exception &e) {
+			EmitError(e.what());
+		} catch (...) {
+			EmitError("unknown error");
+		}
+	}
+	void EmitError(const string &message) {
+		slot.clear();
+		CloudFormationDescribeStacksRow err;
+		err.region = region;
+		err.region_error = message;
+		err.tags = Value(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));    // NULL
+		err.outputs = Value(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)); // NULL
+		slot.push_back(std::move(err));
+	}
+	string region;
+	vector<CloudFormationDescribeStacksRow> &slot;
+};
+
+struct CloudFormationDescribeStacksBindData : public TableFunctionData {
+	vector<string> regions;
+	bool throw_on_region_error = false; // true only for the single-VARCHAR overload
+	bool initialized = false;
+	vector<CloudFormationDescribeStacksRow> rows;
+	idx_t cursor = 0;
+};
+
+static unique_ptr<FunctionData> CloudFormationDescribeStacksBind(ClientContext &context, TableFunctionBindInput &input,
+                                                                 vector<LogicalType> &return_types,
+                                                                 vector<string> &names) {
+	auto result = make_uniq<CloudFormationDescribeStacksBindData>();
+
+	if (input.inputs.empty()) {
+		// No argument: sweep all default regions in parallel.
+		for (auto *r : AWS_DEFAULT_REGIONS) {
+			result->regions.emplace_back(r);
+		}
+	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
+		// Explicit region list: parallel, skip-on-error.
+		if (input.inputs[0].IsNull()) {
+			throw InvalidInputException("cloudformation_describe_stacks: region list must not be NULL");
+		}
+		for (auto &child : ListValue::GetChildren(input.inputs[0])) {
+			if (child.IsNull()) {
+				continue;
+			}
+			auto r = StringValue::Get(child);
+			if (!r.empty()) {
+				result->regions.push_back(r);
+			}
+		}
+		if (result->regions.empty()) {
+			throw InvalidInputException("cloudformation_describe_stacks: region list must not be empty");
+		}
+	} else {
+		// Single explicit region: surface its error rather than silently skipping.
+		if (input.inputs[0].IsNull()) {
+			throw InvalidInputException("cloudformation_describe_stacks: region must not be NULL");
+		}
+		auto r = StringValue::Get(input.inputs[0]);
+		if (r.empty()) {
+			throw InvalidInputException("cloudformation_describe_stacks: region must not be empty");
+		}
+		result->regions.push_back(r);
+		result->throw_on_region_error = true;
+	}
+
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("region");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("stack_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("stack_id");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("status");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("status_reason");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("creation_time");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("last_updated_time");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("description");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	names.emplace_back("tags");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	names.emplace_back("outputs");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("region_error");
+
+	return std::move(result);
+}
+
+static void CloudFormationDescribeStacksFun(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (CloudFormationDescribeStacksBindData &)*data_p.bind_data;
+
+	if (!data.initialized) {
+		if (data.throw_on_region_error) {
+			// Single explicit region: run inline and let its error propagate.
+			DescribeRegionStacks(data.regions[0], data.rows);
+		} else {
+			// Parallel fan-out: one task per region into its own slot; a region that errors is skipped. Fixed-size
+			// `slots` so the vector never reallocates while tasks hold references into it.
+			vector<vector<CloudFormationDescribeStacksRow>> slots(data.regions.size());
+			TaskExecutor executor(context);
+			for (idx_t i = 0; i < data.regions.size(); i++) {
+				executor.ScheduleTask(make_uniq<DescribeRegionTask>(executor, data.regions[i], slots[i]));
+			}
+			executor.WorkOnTasks();
+			for (auto &slot : slots) {
+				for (auto &row : slot) {
+					data.rows.push_back(std::move(row));
+				}
+			}
+		}
+		data.initialized = true;
+	}
+
+	idx_t remaining = data.rows.size() - data.cursor;
+	idx_t to_emit = std::min(remaining, (idx_t)STANDARD_VECTOR_SIZE);
+	for (idx_t i = 0; i < to_emit; i++) {
+		auto &r = data.rows[data.cursor + i];
+		// stack_name/stack_id/status are always set for a real stack and empty for a 'region_error' sentinel,
+		// so empty -> NULL cleanly distinguishes the two without special-casing.
+		output.data[0].Append(Value(r.region));
+		output.data[1].Append(r.stack_name.empty() ? Value() : Value(r.stack_name));
+		output.data[2].Append(r.stack_id.empty() ? Value() : Value(r.stack_id));
+		output.data[3].Append(r.status.empty() ? Value() : Value(r.status));
+		output.data[4].Append(r.status_reason.empty() ? Value() : Value(r.status_reason));
+		output.data[5].Append(r.creation_time.empty() ? Value() : Value(r.creation_time));
+		output.data[6].Append(r.last_updated_time.empty() ? Value() : Value(r.last_updated_time));
+		output.data[7].Append(r.description.empty() ? Value() : Value(r.description));
+		output.data[8].Append(r.tags);
+		output.data[9].Append(r.outputs);
+		output.data[10].Append(r.region_error.empty() ? Value() : Value(r.region_error));
+	}
+	output.CheckCardinality(to_emit);
+	data.cursor += to_emit;
+}
+
+//===--------------------------------------------------------------------===//
 // duckdb_aws_session_id() scalar function
 //===--------------------------------------------------------------------===//
 
@@ -889,6 +1136,17 @@ void CloudFormationFunctions::Register(ExtensionLoader &loader) {
 	                      CloudFormationListStacksBind);
 	list_fn.named_parameters["status_filter"] = LogicalType::LIST(LogicalType::VARCHAR);
 	loader.RegisterFunction(list_fn);
+
+	// Overloaded: no arg -> all default regions (parallel); VARCHAR -> one region; LIST(VARCHAR) -> those
+	// regions (parallel). Bind dispatches on the argument shape.
+	TableFunctionSet describe_all_set("cloudformation_describe_stacks");
+	describe_all_set.AddFunction(
+	    TableFunction({}, CloudFormationDescribeStacksFun, CloudFormationDescribeStacksBind));
+	describe_all_set.AddFunction(
+	    TableFunction({LogicalType::VARCHAR}, CloudFormationDescribeStacksFun, CloudFormationDescribeStacksBind));
+	describe_all_set.AddFunction(TableFunction({LogicalType::LIST(LogicalType::VARCHAR)},
+	                                           CloudFormationDescribeStacksFun, CloudFormationDescribeStacksBind));
+	loader.RegisterFunction(describe_all_set);
 
 	ScalarFunction session_id_fn("duckdb_aws_session_id", {}, LogicalType::VARCHAR, DuckDBAwsSessionIdFunction);
 	loader.RegisterFunction(session_id_fn);

--- a/src/include/quack_on_ec2_resource.hpp
+++ b/src/include/quack_on_ec2_resource.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace duckdb {
+
+class ExtensionLoader;
+
+//! Registers the `aws:cloudformation:quack-on-ec2` external resource type and its native create/status/
+//! destroy callbacks (thin adapters over the generic cloudformation_* table functions). Called from the
+//! aws extension's Load so that `LOAD aws;` makes the type available with no user-authored SQL.
+struct QuackOnEc2Resource {
+	static void Register(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/quack_on_ec2_resource.cpp
+++ b/src/quack_on_ec2_resource.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/main/materialized_query_result.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/main/external_resource_type_registry.hpp"
 
@@ -13,6 +14,11 @@ namespace duckdb {
 // param. Its Outputs expose the keys read by the status callback below (Endpoint, Token).
 static constexpr const char *QUACK_ON_EC2_TEMPLATE =
     "https://test-wasm-carlo.s3.us-east-1.amazonaws.com/duckdb-quack-ec2-template.yaml";
+
+// The external-resource type name, also stamped as a stack tag at create time so the list callback can
+// discover quack-on-ec2 stacks by filtering DescribeStacks output on it.
+static constexpr const char *QUACK_ON_EC2_TYPE = "aws:cloudformation:quack-on-ec2";
+static constexpr const char *RESOURCE_TYPE_TAG = "duckdb-external-resource-type";
 
 namespace {
 
@@ -87,6 +93,12 @@ static void QuackCreateFun(ClientContext &context, TableFunctionInput &data_p, D
 		auto template_params = Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, tp_keys, tp_values);
 		sql += ", template_parameters := " + template_params.ToSQLString();
 	}
+	// Provenance tag so the list callback can discover these stacks by filtering on it (added to, not
+	// replacing, cloudformation_create_stack's own auto-tags like created-by).
+	vector<Value> tag_keys {Value(string(RESOURCE_TYPE_TAG))};
+	vector<Value> tag_values {Value(string(QUACK_ON_EC2_TYPE))};
+	auto resource_tag = Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, tag_keys, tag_values);
+	sql += ", tags := " + resource_tag.ToSQLString();
 	sql += ")";
 
 	Connection con(DatabaseInstance::GetDatabase(context));
@@ -162,6 +174,91 @@ static void QuackDestroyFun(ClientContext &context, TableFunctionInput &data_p, 
 	state.done = true;
 }
 
+// list(params MAP) -> TABLE(handle MAP, reference VARCHAR, state VARCHAR, metadata MAP). Discovers existing
+// quack-on-ec2 stacks (identified by the provenance tag stamped at create) and shapes each into a row whose
+// `handle` is byte-identical to what create returns, so it round-trips through status/destroy verbatim. The
+// connect blob (uri/token) is deliberately NOT surfaced here — list is discovery; resolve/status produce that.
+struct QuackListState : public GlobalTableFunctionState {
+	unique_ptr<MaterializedQueryResult> result;
+	idx_t cursor = 0;
+	bool ran = false;
+};
+
+static unique_ptr<GlobalTableFunctionState> QuackListInit(ClientContext &, TableFunctionInitInput &) {
+	return make_uniq<QuackListState>();
+}
+
+static unique_ptr<FunctionData> QuackListBind(ClientContext &, TableFunctionBindInput &input,
+                                              vector<LogicalType> &return_types, vector<string> &names) {
+	auto result = make_uniq<QuackAdapterBindData>();
+	result->input = input.inputs[0];
+	names.emplace_back("handle");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	names.emplace_back("reference");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("state");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("metadata");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	return std::move(result);
+}
+
+static void QuackListFun(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &state = data_p.global_state->Cast<QuackListState>();
+	auto &bind = data_p.bind_data->Cast<QuackAdapterBindData>();
+
+	if (!state.ran) {
+		// Optional 'region' param: if given, list just that region; otherwise sweep all regions — the parallel
+		// fan-out lives inside cloudformation_describe_stacks, so this stays a single-call SQL adapter.
+		string one_region;
+		if (!bind.input.IsNull()) {
+			for (auto &entry : MapValue::GetChildren(bind.input)) {
+				auto &kv = StructValue::GetChildren(entry);
+				auto key = kv[0].IsNull() ? string() : StringValue::Get(kv[0]);
+				if (key == "region" && !kv[1].IsNull()) {
+					one_region = StringValue::Get(kv[1]);
+				}
+			}
+		}
+		string source = one_region.empty()
+		                    ? "cloudformation_describe_stacks()"
+		                    : "cloudformation_describe_stacks(" + Value(one_region).ToSQLString() + ")";
+
+		auto sql =
+		    "SELECT MAP {'stack_name': stack_name, 'stack_id': stack_id, 'region': region} AS handle, "
+		    "       stack_id AS reference, "
+		    "       CASE WHEN status IN ('CREATE_COMPLETE', 'UPDATE_COMPLETE') THEN 'ready' "
+		    "            WHEN status LIKE 'DELETE_%' THEN 'deleting' "
+		    "            WHEN status LIKE '%ROLLBACK%' OR status LIKE '%FAILED%' THEN 'failed' "
+		    "            ELSE 'pending' END AS state, "
+		    "       MAP {'stack_status': status, 'creation_time': creation_time, "
+		    "            'last_updated_time': last_updated_time, 'description': description} AS metadata "
+		    "FROM " +
+		    source + " WHERE region_error IS NULL AND tags[" + Value(string(RESOURCE_TYPE_TAG)).ToSQLString() +
+		    "] = " + Value(string(QUACK_ON_EC2_TYPE)).ToSQLString();
+
+		Connection con(DatabaseInstance::GetDatabase(context));
+		state.result = con.Query(sql);
+		if (state.result->HasError()) {
+			throw IOException("quack-on-ec2 list failed: %s", state.result->GetError());
+		}
+		state.ran = true;
+	}
+
+	idx_t total = state.result->RowCount();
+	idx_t remaining = total - state.cursor;
+	idx_t to_emit = remaining < (idx_t)STANDARD_VECTOR_SIZE ? remaining : (idx_t)STANDARD_VECTOR_SIZE;
+	for (idx_t i = 0; i < to_emit; i++) {
+		idx_t row = state.cursor + i;
+		output.data[0].Append(state.result->GetValue(0, row));
+		output.data[1].Append(state.result->GetValue(1, row));
+		output.data[2].Append(state.result->GetValue(2, row));
+		output.data[3].Append(state.result->GetValue(3, row));
+	}
+	output.CheckCardinality(to_emit);
+	state.cursor += to_emit;
+}
+
 } // namespace
 
 void QuackOnEc2Resource::Register(ExtensionLoader &loader) {
@@ -174,6 +271,10 @@ void QuackOnEc2Resource::Register(ExtensionLoader &loader) {
 	loader.RegisterFunction(status_fn);
 	TableFunction destroy_fn("__aws__cloudformation__quack_on_ec2__destroy", {map_vv}, QuackDestroyFun, QuackDestroyBind, QuackAdapterInit);
 	loader.RegisterFunction(destroy_fn);
+	// Registered as a plain callable function only. Wiring it into the resource-type registry (a `list_function`
+	// slot) is a separate duckdb-side change, done elsewhere.
+	TableFunction list_fn("__aws__cloudformation__quack_on_ec2__list", {map_vv}, QuackListFun, QuackListBind, QuackListInit);
+	loader.RegisterFunction(list_fn);
 
 	// Register the resource type on the C++ side (origin = "extension"), so `LOAD aws;` is all a user needs.
 	ExternalResourceType type;

--- a/src/quack_on_ec2_resource.cpp
+++ b/src/quack_on_ec2_resource.cpp
@@ -1,0 +1,189 @@
+#include "quack_on_ec2_resource.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/main/external_resource_type_registry.hpp"
+
+namespace duckdb {
+
+// Default CloudFormation template for a quack-on-EC2 stack; overridable per-call via the 'template' create
+// param. Its Outputs expose the keys read by the status callback below (Endpoint, Token).
+static constexpr const char *QUACK_ON_EC2_TEMPLATE =
+    "https://test-wasm-carlo.s3.us-east-1.amazonaws.com/duckdb-quack-ec2-template.yaml";
+
+namespace {
+
+// The recipe callbacks are thin native table functions that adapt the generic cloudformation_* shapes to
+// the external-resource contract: create(params)->handle, status(handle)->(state,result), destroy(handle).
+// The adaptation itself lives in the SQL each callback runs against the cloudformation_* functions on an
+// internal connection (same pattern as create_external_resource) — so no user-authored SQL macros.
+
+struct QuackAdapterBindData : public TableFunctionData {
+	Value input; // params (create) or handle (status/destroy)
+};
+
+struct QuackAdapterState : public GlobalTableFunctionState {
+	bool done = false;
+};
+
+static unique_ptr<GlobalTableFunctionState> QuackAdapterInit(ClientContext &, TableFunctionInitInput &) {
+	return make_uniq<QuackAdapterState>();
+}
+
+// create(params MAP) -> TABLE(handle MAP). cloudformation_create_stack takes only the template positionally;
+// the recipe params supply the (required) region and the template_parameters. `template` and `region` are
+// pulled out here in C++ and everything else becomes template_parameters — built as a literal MAP so it is
+// NOT assembled inline in the table-function argument (where `e.key`-style identifiers get silently coerced
+// to strings by the identifier-conversion rule, which would defeat the filter and leak `region`).
+static unique_ptr<FunctionData> QuackCreateBind(ClientContext &, TableFunctionBindInput &input,
+                                                vector<LogicalType> &return_types, vector<string> &names) {
+	auto result = make_uniq<QuackAdapterBindData>();
+	result->input = input.inputs[0];
+	names.emplace_back("handle");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	return std::move(result);
+}
+
+static void QuackCreateFun(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &state = data_p.global_state->Cast<QuackAdapterState>();
+	if (state.done) {
+		return;
+	}
+	auto &bind = data_p.bind_data->Cast<QuackAdapterBindData>();
+
+	// Split the params MAP in C++: `template` (default), required `region`, rest -> template_parameters.
+	string template_url = QUACK_ON_EC2_TEMPLATE;
+	string region;
+	vector<Value> tp_keys, tp_values;
+	if (!bind.input.IsNull()) {
+		for (auto &entry : MapValue::GetChildren(bind.input)) {
+			auto &kv = StructValue::GetChildren(entry);
+			auto key = kv[0].IsNull() ? string() : StringValue::Get(kv[0]);
+			if (key == "template") {
+				if (!kv[1].IsNull()) {
+					template_url = StringValue::Get(kv[1]);
+				}
+			} else if (key == "region") {
+				if (!kv[1].IsNull()) {
+					region = StringValue::Get(kv[1]);
+				}
+			} else {
+				tp_keys.push_back(kv[0]);
+				tp_values.push_back(kv[1]);
+			}
+		}
+	}
+	if (region.empty()) {
+		throw InvalidInputException("quack-on-ec2 create: the 'region' param is required");
+	}
+
+	// Pass literals only — no inline map-building in the table-function argument (see comment above).
+	auto sql = "SELECT handle FROM cloudformation_create_stack(" + Value(template_url).ToSQLString() +
+	           ", region := " + Value(region).ToSQLString();
+	if (!tp_keys.empty()) {
+		auto template_params = Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, tp_keys, tp_values);
+		sql += ", template_parameters := " + template_params.ToSQLString();
+	}
+	sql += ")";
+
+	Connection con(DatabaseInstance::GetDatabase(context));
+	auto res = con.Query(sql);
+	if (res->HasError()) {
+		throw IOException("quack-on-ec2 create failed: %s", res->GetError());
+	}
+	output.data[0].Append(res->GetValue(0, 0));
+	state.done = true;
+}
+
+// status(handle MAP) -> TABLE(state VARCHAR, result MAP). Maps the CloudFormation stack status onto the
+// terminal 'ready'/'failed' states the poll loop expects, and projects the stack Outputs into the connect
+// endpoint (uri + attached_db_type + token). cloudformation_describe_stack is unchanged by 0002.
+static unique_ptr<FunctionData> QuackStatusBind(ClientContext &, TableFunctionBindInput &input,
+                                                vector<LogicalType> &return_types, vector<string> &names) {
+	auto result = make_uniq<QuackAdapterBindData>();
+	result->input = input.inputs[0];
+	names.emplace_back("state");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("result");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	return std::move(result);
+}
+
+static void QuackStatusFun(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &state = data_p.global_state->Cast<QuackAdapterState>();
+	if (state.done) {
+		return;
+	}
+	auto &bind = data_p.bind_data->Cast<QuackAdapterBindData>();
+	Connection con(DatabaseInstance::GetDatabase(context));
+	auto sql =
+	    "SELECT CASE WHEN status = 'CREATE_COMPLETE' THEN 'ready' "
+	    "            WHEN status LIKE '%ROLLBACK%' OR status LIKE '%FAILED%' THEN 'failed' "
+	    "            ELSE 'pending' END AS state, "
+	    "       MAP {'uri': outputs['QuackURI'], 'attached_db_type': 'quack', "
+	    "            'token': split_part(split_part(outputs['Token'], '{\"1\":\"', 2), '\"}', 1)} AS result "
+	    "FROM cloudformation_describe_stack(" +
+	    bind.input.ToSQLString() + ")";
+	auto res = con.Query(sql);
+	if (res->HasError()) {
+		throw IOException("quack-on-ec2 status failed: %s", res->GetError());
+	}
+	output.data[0].Append(res->GetValue(0, 0));
+	output.data[1].Append(res->GetValue(1, 0));
+	state.done = true;
+}
+
+// destroy(handle MAP) -> TABLE(status VARCHAR)
+static unique_ptr<FunctionData> QuackDestroyBind(ClientContext &, TableFunctionBindInput &input,
+                                                 vector<LogicalType> &return_types, vector<string> &names) {
+	auto result = make_uniq<QuackAdapterBindData>();
+	result->input = input.inputs[0];
+	names.emplace_back("status");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	return std::move(result);
+}
+
+static void QuackDestroyFun(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &state = data_p.global_state->Cast<QuackAdapterState>();
+	if (state.done) {
+		return;
+	}
+	auto &bind = data_p.bind_data->Cast<QuackAdapterBindData>();
+	Connection con(DatabaseInstance::GetDatabase(context));
+	auto sql = "SELECT 'deleting' AS status FROM cloudformation_delete_stack(" + bind.input.ToSQLString() + ")";
+	auto res = con.Query(sql);
+	if (res->HasError()) {
+		throw IOException("quack-on-ec2 destroy failed: %s", res->GetError());
+	}
+	output.data[0].Append(Value("deleting"));
+	state.done = true;
+}
+
+} // namespace
+
+void QuackOnEc2Resource::Register(ExtensionLoader &loader) {
+	auto map_vv = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
+
+	// Native callbacks (no SQL macros): thin adapters over cloudformation_*.
+	TableFunction create_fn("__aws__cloudformation__quack_on_ec2__create", {map_vv}, QuackCreateFun, QuackCreateBind, QuackAdapterInit);
+	loader.RegisterFunction(create_fn);
+	TableFunction status_fn("__aws__cloudformation__quack_on_ec2__status", {map_vv}, QuackStatusFun, QuackStatusBind, QuackAdapterInit);
+	loader.RegisterFunction(status_fn);
+	TableFunction destroy_fn("__aws__cloudformation__quack_on_ec2__destroy", {map_vv}, QuackDestroyFun, QuackDestroyBind, QuackAdapterInit);
+	loader.RegisterFunction(destroy_fn);
+
+	// Register the resource type on the C++ side (origin = "extension"), so `LOAD aws;` is all a user needs.
+	ExternalResourceType type;
+	type.name = "aws:cloudformation:quack-on-ec2";
+	type.kind = "catalog";
+	type.create_function = "__aws__cloudformation__quack_on_ec2__create";
+	type.status_function = "__aws__cloudformation__quack_on_ec2__status";
+	type.destroy_function = "__aws__cloudformation__quack_on_ec2__destroy";
+	type.origin = "extension";
+	ExternalResourceTypeRegistry::Get(loader.GetDatabaseInstance()).Add(std::move(type));
+}
+
+} // namespace duckdb

--- a/src/quack_on_ec2_resource.cpp
+++ b/src/quack_on_ec2_resource.cpp
@@ -131,14 +131,13 @@ static void QuackStatusFun(ClientContext &context, TableFunctionInput &data_p, D
 	}
 	auto &bind = data_p.bind_data->Cast<QuackAdapterBindData>();
 	Connection con(DatabaseInstance::GetDatabase(context));
-	auto sql =
-	    "SELECT CASE WHEN status = 'CREATE_COMPLETE' THEN 'ready' "
-	    "            WHEN status LIKE '%ROLLBACK%' OR status LIKE '%FAILED%' THEN 'failed' "
-	    "            ELSE 'pending' END AS state, "
-	    "       MAP {'uri': outputs['QuackURI'], 'attached_db_type': 'quack', "
-	    "            'token': split_part(split_part(outputs['Token'], '{\"1\":\"', 2), '\"}', 1)} AS result "
-	    "FROM cloudformation_describe_stack(" +
-	    bind.input.ToSQLString() + ")";
+	auto sql = "SELECT CASE WHEN status = 'CREATE_COMPLETE' THEN 'ready' "
+	           "            WHEN status LIKE '%ROLLBACK%' OR status LIKE '%FAILED%' THEN 'failed' "
+	           "            ELSE 'pending' END AS state, "
+	           "       MAP {'uri': outputs['QuackURI'], 'attached_db_type': 'quack', "
+	           "            'token': split_part(split_part(outputs['Token'], '{\"1\":\"', 2), '\"}', 1)} AS result "
+	           "FROM cloudformation_describe_stack(" +
+	           bind.input.ToSQLString() + ")";
 	auto res = con.Query(sql);
 	if (res->HasError()) {
 		throw IOException("quack-on-ec2 status failed: %s", res->GetError());
@@ -220,22 +219,20 @@ static void QuackListFun(ClientContext &context, TableFunctionInput &data_p, Dat
 				}
 			}
 		}
-		string source = one_region.empty()
-		                    ? "cloudformation_describe_stacks()"
-		                    : "cloudformation_describe_stacks(" + Value(one_region).ToSQLString() + ")";
+		string source = one_region.empty() ? "cloudformation_describe_stacks()"
+		                                   : "cloudformation_describe_stacks(" + Value(one_region).ToSQLString() + ")";
 
-		auto sql =
-		    "SELECT MAP {'stack_name': stack_name, 'stack_id': stack_id, 'region': region} AS handle, "
-		    "       stack_id AS reference, "
-		    "       CASE WHEN status IN ('CREATE_COMPLETE', 'UPDATE_COMPLETE') THEN 'ready' "
-		    "            WHEN status LIKE 'DELETE_%' THEN 'deleting' "
-		    "            WHEN status LIKE '%ROLLBACK%' OR status LIKE '%FAILED%' THEN 'failed' "
-		    "            ELSE 'pending' END AS state, "
-		    "       MAP {'stack_status': status, 'creation_time': creation_time, "
-		    "            'last_updated_time': last_updated_time, 'description': description} AS metadata "
-		    "FROM " +
-		    source + " WHERE region_error IS NULL AND tags[" + Value(string(RESOURCE_TYPE_TAG)).ToSQLString() +
-		    "] = " + Value(string(QUACK_ON_EC2_TYPE)).ToSQLString();
+		auto sql = "SELECT MAP {'stack_name': stack_name, 'stack_id': stack_id, 'region': region} AS handle, "
+		           "       stack_id AS reference, "
+		           "       CASE WHEN status IN ('CREATE_COMPLETE', 'UPDATE_COMPLETE') THEN 'ready' "
+		           "            WHEN status LIKE 'DELETE_%' THEN 'deleting' "
+		           "            WHEN status LIKE '%ROLLBACK%' OR status LIKE '%FAILED%' THEN 'failed' "
+		           "            ELSE 'pending' END AS state, "
+		           "       MAP {'stack_status': status, 'creation_time': creation_time, "
+		           "            'last_updated_time': last_updated_time, 'description': description} AS metadata "
+		           "FROM " +
+		           source + " WHERE region_error IS NULL AND tags[" + Value(string(RESOURCE_TYPE_TAG)).ToSQLString() +
+		           "] = " + Value(string(QUACK_ON_EC2_TYPE)).ToSQLString();
 
 		Connection con(DatabaseInstance::GetDatabase(context));
 		state.result = con.Query(sql);
@@ -265,15 +262,19 @@ void QuackOnEc2Resource::Register(ExtensionLoader &loader) {
 	auto map_vv = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
 
 	// Native callbacks (no SQL macros): thin adapters over cloudformation_*.
-	TableFunction create_fn("__aws__cloudformation__quack_on_ec2__create", {map_vv}, QuackCreateFun, QuackCreateBind, QuackAdapterInit);
+	TableFunction create_fn("__aws__cloudformation__quack_on_ec2__create", {map_vv}, QuackCreateFun, QuackCreateBind,
+	                        QuackAdapterInit);
 	loader.RegisterFunction(create_fn);
-	TableFunction status_fn("__aws__cloudformation__quack_on_ec2__status", {map_vv}, QuackStatusFun, QuackStatusBind, QuackAdapterInit);
+	TableFunction status_fn("__aws__cloudformation__quack_on_ec2__status", {map_vv}, QuackStatusFun, QuackStatusBind,
+	                        QuackAdapterInit);
 	loader.RegisterFunction(status_fn);
-	TableFunction destroy_fn("__aws__cloudformation__quack_on_ec2__destroy", {map_vv}, QuackDestroyFun, QuackDestroyBind, QuackAdapterInit);
+	TableFunction destroy_fn("__aws__cloudformation__quack_on_ec2__destroy", {map_vv}, QuackDestroyFun,
+	                         QuackDestroyBind, QuackAdapterInit);
 	loader.RegisterFunction(destroy_fn);
 	// Registered as a plain callable function only. Wiring it into the resource-type registry (a `list_function`
 	// slot) is a separate duckdb-side change, done elsewhere.
-	TableFunction list_fn("__aws__cloudformation__quack_on_ec2__list", {map_vv}, QuackListFun, QuackListBind, QuackListInit);
+	TableFunction list_fn("__aws__cloudformation__quack_on_ec2__list", {map_vv}, QuackListFun, QuackListBind,
+	                      QuackListInit);
 	loader.RegisterFunction(list_fn);
 
 	// Register the resource type on the C++ side (origin = "extension"), so `LOAD aws;` is all a user needs.


### PR DESCRIPTION
Two pieces:
1. add external resource `aws:cloudformation:quack-on-ec2` (based on  machinery at https://github.com/duckdb/duckdb/pull/23731)
2. add cloudformation_list_stacks() that perform parallel cross region listing. That combined with filtering allows to list external resources

First piece allows to create resources of type `aws:cloudformation:quack-on-ec2`, poll for completion, and then

Second piece allows to list `cloudformation`'s stacks, it can be paired with previous features, and could be both of general utility, example:
```sql
SELECT region, stack_name, status, creation_time, region_error
      FROM cloudformation_describe_stacks();
```
```
     ┌───────────┬───────────────┬─────────────────┬──────────────────────┬──────────────┐
     │  region   │  stack_name   │     status      │    creation_time     │ region_error │
     ├───────────┼───────────────┼─────────────────┼──────────────────────┼──────────────┤
     │ us-east-1 │ quack-mailbox │ CREATE_COMPLETE │ 2026-06-25T15:21:59Z │ NULL         │
     │ us-east-1 │ quack-setup   │ UPDATE_COMPLETE │ 2026-06-26T09:06:13Z │ NULL         │
     └───────────┴───────────────┴─────────────────┴──────────────────────┴──────────────┘
```
(and indeed, I have at the moment only `us-east-1` stacks)

Note that there are now 3 versions of listing:
  - `cloudformation_describe_stacks()` → all 17 default regions, parallel, skip-on-error (sentinel rows).
  - `cloudformation_describe_stacks('us-east-1')` → one region, throws on error.
  - `cloudformation_describe_stacks(['us-east-1','eu-west-1'])` → those regions, parallel, skip-on-error.