### PR TITLE
Move default region list to a GetDefaultAwsRegions() utility

### DIFF
--- a/src/cloudformation_functions.cpp
+++ b/src/cloudformation_functions.cpp
@@ -875,8 +875,9 @@ struct CloudFormationDescribeStacksRow {
 	Value tags;
 	Value outputs;
 	// Empty for a real stack; the AWS error message for a failed-region sentinel row (region set, all stack
-	// columns NULL). Discriminates the two row kinds: real stacks have region_error IS NULL.
-	string region_error;
+	// columns NULL). Discriminates the two row kinds: real stacks have error IS NULL. Named generically (not
+	// region_error) so it can carry other, non-region error conditions later.
+	string error;
 };
 
 // Fetch all stacks in one region (paginated), appending to `out`. Throws on AWS error.
@@ -939,7 +940,7 @@ static void DescribeRegionStacks(const string &region, vector<CloudFormationDesc
 }
 
 // One region's DescribeStacks as a scheduler task. Catches its own AWS error (never PushError, which would
-// abort the whole sweep via WorkOnTasks) and replaces its slot with a single 'region_error' sentinel row, so
+// abort the whole sweep via WorkOnTasks) and replaces its slot with a single 'error' sentinel row, so
 // a dead region is surfaced-but-not-fatal instead of silently vanishing.
 struct DescribeRegionTask : public BaseExecutorTask {
 	DescribeRegionTask(TaskExecutor &executor, string region_p, vector<CloudFormationDescribeStacksRow> &slot_p)
@@ -958,7 +959,7 @@ struct DescribeRegionTask : public BaseExecutorTask {
 		slot.clear();
 		CloudFormationDescribeStacksRow err;
 		err.region = region;
-		err.region_error = message;
+		err.error = message;
 		err.tags = Value(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));    // NULL
 		err.outputs = Value(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)); // NULL
 		slot.push_back(std::move(err));
@@ -1034,7 +1035,7 @@ static unique_ptr<FunctionData> CloudFormationDescribeStacksBind(ClientContext &
 	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
 	names.emplace_back("outputs");
 	return_types.emplace_back(LogicalType::VARCHAR);
-	names.emplace_back("region_error");
+	names.emplace_back("error");
 
 	return std::move(result);
 }
@@ -1068,7 +1069,7 @@ static void CloudFormationDescribeStacksFun(ClientContext &context, TableFunctio
 	idx_t to_emit = std::min(remaining, (idx_t)STANDARD_VECTOR_SIZE);
 	for (idx_t i = 0; i < to_emit; i++) {
 		auto &r = data.rows[data.cursor + i];
-		// stack_name/stack_id/status are always set for a real stack and empty for a 'region_error' sentinel,
+		// stack_name/stack_id/status are always set for a real stack and empty for an 'error' sentinel,
 		// so empty -> NULL cleanly distinguishes the two without special-casing.
 		output.data[0].Append(Value(r.region));
 		output.data[1].Append(r.stack_name.empty() ? Value() : Value(r.stack_name));
@@ -1080,7 +1081,7 @@ static void CloudFormationDescribeStacksFun(ClientContext &context, TableFunctio
 		output.data[7].Append(r.description.empty() ? Value() : Value(r.description));
 		output.data[8].Append(r.tags);
 		output.data[9].Append(r.outputs);
-		output.data[10].Append(r.region_error.empty() ? Value() : Value(r.region_error));
+		output.data[10].Append(r.error.empty() ? Value() : Value(r.error));
 	}
 	output.CheckCardinality(to_emit);
 	data.cursor += to_emit;

--- a/src/cloudformation_functions.cpp
+++ b/src/cloudformation_functions.cpp
@@ -1,5 +1,6 @@
 #include "cloudformation_functions.hpp"
 #include "aws_client.hpp"
+#include "utils/utils.hpp"
 
 #include "duckdb.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
@@ -862,14 +863,6 @@ static void CloudFormationListStacksFun(ClientContext &context, TableFunctionInp
 // failing the whole sweep.
 //===--------------------------------------------------------------------===//
 
-// Default-enabled commercial regions swept by the no-argument overload. Hardcoded for now; live enumeration
-// (ec2:DescribeRegions / account:ListRegions) is the accuracy follow-up so newly-enabled opt-in regions are
-// not silently missed.
-static const char *const AWS_DEFAULT_REGIONS[] = {
-    "us-east-1",      "us-east-2",      "us-west-1",      "us-west-2",      "ca-central-1",  "sa-east-1",
-    "eu-west-1",      "eu-west-2",      "eu-west-3",      "eu-central-1",   "eu-north-1",    "ap-south-1",
-    "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-southeast-1", "ap-southeast-2"};
-
 struct CloudFormationDescribeStacksRow {
 	string region;
 	string stack_name;
@@ -989,9 +982,7 @@ static unique_ptr<FunctionData> CloudFormationDescribeStacksBind(ClientContext &
 
 	if (input.inputs.empty()) {
 		// No argument: sweep all default regions in parallel.
-		for (auto *r : AWS_DEFAULT_REGIONS) {
-			result->regions.emplace_back(r);
-		}
+		result->regions = GetDefaultAwsRegions();
 	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
 		// Explicit region list: parallel, skip-on-error.
 		if (input.inputs[0].IsNull()) {

--- a/src/include/utils/utils.hpp
+++ b/src/include/utils/utils.hpp
@@ -18,6 +18,10 @@ namespace duckdb {
 //! https://docs.aws.amazon.com/sdkref/latest/guide/feature-region.html
 string ResolveAwsRegion(ClientContext &context, const string &explicit_region, const string &profile_name);
 
+//! The default-enabled commercial AWS regions, used as the sweep set for multi-region listing functions
+//! (e.g. the no-argument cloudformation_describe_stacks). Hardcoded for now — see the FIXME in utils.cpp.
+const vector<string> &GetDefaultAwsRegions();
+
 //! Secret types that carry an AWS identity, in the order they should be preferred: 'aws' is the
 //! generic one, 's3' holds the same credentials alongside bucket settings.
 const vector<string> &AwsSecretTypes();

--- a/src/quack_on_ec2_resource.cpp
+++ b/src/quack_on_ec2_resource.cpp
@@ -231,7 +231,7 @@ static void QuackListFun(ClientContext &context, TableFunctionInput &data_p, Dat
 		           "       MAP {'stack_status': status, 'creation_time': creation_time, "
 		           "            'last_updated_time': last_updated_time, 'description': description} AS metadata "
 		           "FROM " +
-		           source + " WHERE region_error IS NULL AND tags[" + Value(string(RESOURCE_TYPE_TAG)).ToSQLString() +
+		           source + " WHERE error IS NULL AND tags[" + Value(string(RESOURCE_TYPE_TAG)).ToSQLString() +
 		           "] = " + Value(string(QUACK_ON_EC2_TYPE)).ToSQLString();
 
 		Connection con(DatabaseInstance::GetDatabase(context));

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -53,6 +53,20 @@ string ResolveAwsRegion(ClientContext &context, const string &explicit_region, c
 	return RegionFromProfile(profile_name);
 }
 
+const vector<string> &GetDefaultAwsRegions() {
+	// FIXME: hardcoded, default-enabled commercial regions only. Replace with live enumeration
+	// (ec2:DescribeRegions or account:ListRegions) so newly-enabled opt-in regions are picked up automatically
+	// and aws-cn / aws-us-gov callers get their own partition's regions (a client's credentials are partition-
+	// scoped, so DescribeRegions run from the caller's region is inherently partition-correct). Blocked on
+	// linking the ec2 (or account) SDK component, which is not currently built. Until then, a caller using
+	// non-commercial credentials sees every region below fail as an `error` sentinel row.
+	static const vector<string> regions = {
+	    "us-east-1",      "us-east-2",      "us-west-1",      "us-west-2",      "ca-central-1", "sa-east-1",
+	    "eu-west-1",      "eu-west-2",      "eu-west-3",      "eu-central-1",   "eu-north-1",   "ap-south-1",
+	    "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-southeast-1", "ap-southeast-2"};
+	return regions;
+}
+
 const vector<string> &AwsSecretTypes() {
 	static const vector<string> aws_secret_types = {"aws", "s3"};
 	return aws_secret_types;

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -61,8 +61,8 @@ const vector<string> &GetDefaultAwsRegions() {
 	// linking the ec2 (or account) SDK component, which is not currently built. Until then, a caller using
 	// non-commercial credentials sees every region below fail as an `error` sentinel row.
 	static const vector<string> regions = {
-	    "us-east-1",      "us-east-2",      "us-west-1",      "us-west-2",      "ca-central-1", "sa-east-1",
-	    "eu-west-1",      "eu-west-2",      "eu-west-3",      "eu-central-1",   "eu-north-1",   "ap-south-1",
+	    "us-east-1",      "us-east-2",      "us-west-1",      "us-west-2",      "ca-central-1",  "sa-east-1",
+	    "eu-west-1",      "eu-west-2",      "eu-west-3",      "eu-central-1",   "eu-north-1",    "ap-south-1",
 	    "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-southeast-1", "ap-southeast-2"};
 	return regions;
 }


### PR DESCRIPTION
Addresses review feedback on #167: the hardcoded region sweep set no longer lives inline in cloudformation_functions.cpp. A `// FIXME` records the plan to replace it with live ec2:DescribeRegions/account:ListRegions enumeration.

Thanks @Tmonster for the comment in the PR.