### PR TITLE
Allow to wire all AWS network interactions via DuckDB's HTTPUtil interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,8 @@ if(NOT DUCKDB_AWS_GIT_SHA)
 endif()
 add_compile_definitions(DUCKDB_AWS_GIT_SHA="${DUCKDB_AWS_GIT_SHA}")
 
-set(EXTENSION_SOURCES src/aws_extension.cpp src/aws_secret.cpp src/cloudformation_functions.cpp
+set(EXTENSION_SOURCES src/aws_extension.cpp src/aws_secret.cpp src/aws_http_client.cpp
+                      src/cloudformation_functions.cpp
                       src/rds/rds_utils.cpp src/rds/rds_storage.cpp
                       src/quack_on_ec2_resource.cpp
                       src/redshift/redshift_utils.cpp src/redshift/redshift_storage.cpp

--- a/src/aws_extension.cpp
+++ b/src/aws_extension.cpp
@@ -22,8 +22,18 @@ static void LoadInternal(ExtensionLoader &loader) {
 	Aws::SDKOptions options;
 	Aws::InitAPI(options);
 
+	// Toggle for the HTTPUtil bridge below (default true). When false the SDK uses
+	// its own HTTP transport; ignored under wasm, where the bridge is the only path.
+	DBConfig::GetConfig(loader.GetDatabaseInstance())
+	    .AddExtensionOption("aws_network_calls_via_duckdb",
+	                        "Route all AWS SDK network calls through DuckDB's HTTP layer (httpfs transport) "
+	                        "instead of the AWS SDK's own HTTP client. Required under WebAssembly; on native it "
+	                        "avoids statically linking libcurl and patching its CA-certificate path. Default true.",
+	                        LogicalType::BOOLEAN, Value::BOOLEAN(true));
+
 	// Route all AWS SDK HTTP through DuckDB's HTTPUtil (curl via httpfs natively,
-	// browser fetch under wasm). Must run before any AWS client is constructed.
+	// browser fetch under wasm). Must run before any AWS client is constructed. The
+	// factory reads aws_network_calls_via_duckdb per client, so the toggle is live.
 	RegisterDuckDBAwsHttpClientFactory(loader.GetDatabaseInstance());
 
 	CreateAwsSecretFunctions::InitializeCurlCertificates(loader.GetDatabaseInstance());

--- a/src/aws_extension.cpp
+++ b/src/aws_extension.cpp
@@ -1,5 +1,6 @@
 #include "aws_secret.hpp"
 #include "aws_extension.hpp"
+#include "aws_http_client.hpp"
 #include "cloudformation_functions.hpp"
 #include "rds/rds_utils.hpp"
 #include "quack_on_ec2_resource.hpp"
@@ -20,6 +21,10 @@ namespace duckdb {
 static void LoadInternal(ExtensionLoader &loader) {
 	Aws::SDKOptions options;
 	Aws::InitAPI(options);
+
+	// Route all AWS SDK HTTP through DuckDB's HTTPUtil (curl via httpfs natively,
+	// browser fetch under wasm). Must run before any AWS client is constructed.
+	RegisterDuckDBAwsHttpClientFactory(loader.GetDatabaseInstance());
 
 	CreateAwsSecretFunctions::InitializeCurlCertificates(loader.GetDatabaseInstance());
 	CreateAwsSecretFunctions::Register(loader);

--- a/src/aws_extension.cpp
+++ b/src/aws_extension.cpp
@@ -20,8 +20,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	Aws::SDKOptions options;
 	Aws::InitAPI(options);
 
-	// Toggle for the HTTPUtil bridge below (default true). When false the SDK uses
-	// its own HTTP transport; ignored under wasm, where the bridge is the only path.
+	// Ignored under wasm, where the bridge is the only path.
 	DBConfig::GetConfig(loader.GetDatabaseInstance())
 	    .AddExtensionOption("aws_network_calls_via_duckdb",
 	                        "Route all AWS SDK network calls through DuckDB's HTTP layer (httpfs transport) "
@@ -29,9 +28,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                        "avoids statically linking libcurl and patching its CA-certificate path. Default true.",
 	                        LogicalType::BOOLEAN, Value::BOOLEAN(true));
 
-	// Route all AWS SDK HTTP through DuckDB's HTTPUtil (curl via httpfs natively,
-	// browser fetch under wasm). Must run before any AWS client is constructed. The
-	// factory reads aws_network_calls_via_duckdb per client, so the toggle is live.
+	// Must run before any AWS client is constructed. The factory reads the setting per
+	// client, so the toggle stays live.
 	RegisterDuckDBAwsHttpClientFactory(loader.GetDatabaseInstance());
 
 	CreateAwsSecretFunctions::InitializeCurlCertificates(loader.GetDatabaseInstance());

--- a/src/aws_extension.cpp
+++ b/src/aws_extension.cpp
@@ -20,13 +20,15 @@ static void LoadInternal(ExtensionLoader &loader) {
 	Aws::SDKOptions options;
 	Aws::InitAPI(options);
 
-	// Ignored under wasm, where the bridge is the only path.
+	// Ignored under wasm, where the bridge is the only path. Registered as GLOBAL: the client
+	// factory reads this off the DatabaseInstance, which never sees a session-scoped value, so
+	// the default SESSION scope would make a plain SET silently do nothing.
 	DBConfig::GetConfig(loader.GetDatabaseInstance())
 	    .AddExtensionOption("aws_network_calls_via_duckdb",
 	                        "Route all AWS SDK network calls through DuckDB's HTTP layer (httpfs transport) "
 	                        "instead of the AWS SDK's own HTTP client. Required under WebAssembly; on native it "
 	                        "avoids statically linking libcurl and patching its CA-certificate path. Default true.",
-	                        LogicalType::BOOLEAN, Value::BOOLEAN(true));
+	                        LogicalType::BOOLEAN, Value::BOOLEAN(true), nullptr, SetScope::GLOBAL);
 
 	// Must run before any AWS client is constructed. The factory reads the setting per
 	// client, so the toggle stays live.

--- a/src/aws_http_client.cpp
+++ b/src/aws_http_client.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/http_util.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/value.hpp"
 #include "duckdb/main/database.hpp"
 
 #include <aws/core/http/HttpClient.h>
@@ -9,6 +10,12 @@
 #include <aws/core/http/HttpRequest.h>
 #include <aws/core/http/standard/StandardHttpRequest.h>
 #include <aws/core/http/standard/StandardHttpResponse.h>
+#ifndef __EMSCRIPTEN__
+// The opt-out path (aws_network_calls_via_duckdb = false) hands back the SDK's
+// own transport. Under emscripten curl is not built, so this is native-only and
+// the setting is effectively forced on there.
+#include <aws/core/http/curl/CurlHttpClient.h>
+#endif
 
 #include <sstream>
 
@@ -20,7 +27,22 @@
 
 namespace duckdb {
 
+//! The setting that toggles this bridge. Default true: all AWS SDK network calls
+//! go through DuckDB's HTTPUtil. Set false (native only) to fall back to the SDK's
+//! own HTTP transport.
+static constexpr const char *NETWORK_VIA_DUCKDB_SETTING = "aws_network_calls_via_duckdb";
+
 namespace {
+
+//! Read the toggle from the database's current settings. Defaults to true when the
+//! option is unset or unreadable, so the bridge is on unless explicitly disabled.
+bool NetworkCallsViaDuckDB(DatabaseInstance &db) {
+	Value value;
+	if (db.TryGetCurrentSetting(NETWORK_VIA_DUCKDB_SETTING, value) && !value.IsNull()) {
+		return BooleanValue::Get(value);
+	}
+	return true;
+}
 
 RequestType ToDuckDBRequestType(Aws::Http::HttpMethod method) {
 	switch (method) {
@@ -202,7 +224,14 @@ public:
 	}
 
 	std::shared_ptr<Aws::Http::HttpClient>
-	CreateHttpClient(const Aws::Client::ClientConfiguration &) const override {
+	CreateHttpClient(const Aws::Client::ClientConfiguration &config) const override {
+#ifndef __EMSCRIPTEN__
+		// Opt-out (native only): hand back the SDK's own curl transport, exactly as
+		// the default factory would, so behaviour matches a build without this bridge.
+		if (!NetworkCallsViaDuckDB(db)) {
+			return Aws::MakeShared<Aws::Http::CurlHttpClient>("DuckDBAwsHttp", config);
+		}
+#endif
 		return Aws::MakeShared<DuckDBAwsHttpClient>("DuckDBAwsHttp", db);
 	}
 

--- a/src/aws_http_client.cpp
+++ b/src/aws_http_client.cpp
@@ -10,11 +10,20 @@
 #include <aws/core/http/HttpRequest.h>
 #include <aws/core/http/standard/StandardHttpRequest.h>
 #include <aws/core/http/standard/StandardHttpResponse.h>
-#ifndef __EMSCRIPTEN__
 // The opt-out path (aws_network_calls_via_duckdb = false) hands back the SDK's
-// own transport. Under emscripten curl is not built, so this is native-only and
-// the setting is effectively forced on there.
+// own transport, which differs per platform: WinHTTP on Windows, curl elsewhere.
+// The SDK only installs the headers for the transport it was built with, so this
+// selection has to mirror the SDK's own DefaultHttpClientFactory. Under emscripten
+// neither is built, so there the setting is effectively forced on.
+#ifdef __EMSCRIPTEN__
+#define AWS_HTTP_SDK_FALLBACK 0
+#else
+#define AWS_HTTP_SDK_FALLBACK 1
+#ifdef _WIN32
+#include <aws/core/http/windows/WinHttpSyncHttpClient.h>
+#else
 #include <aws/core/http/curl/CurlHttpClient.h>
+#endif
 #endif
 
 #include <sstream>
@@ -111,7 +120,7 @@ public:
 
 	std::shared_ptr<Aws::Http::HttpResponse>
 	MakeRequest(const std::shared_ptr<Aws::Http::HttpRequest> &request,
-	            Aws::Utils::RateLimits::RateLimiterInterface *, // read limiter unused
+	            Aws::Utils::RateLimits::RateLimiterInterface *,                  // read limiter unused
 	            Aws::Utils::RateLimits::RateLimiterInterface *) const override { // write limiter unused
 		auto aws_response = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>("DuckDBAwsHttp", request);
 
@@ -169,8 +178,8 @@ public:
 			case RequestType::PUT_REQUEST: {
 				body_buffer = ReadRequestBody(request);
 				string content_type = request->GetContentType().c_str();
-				PutRequestInfo info(url, headers, *params, const_data_ptr_cast(body_buffer.c_str()),
-				                    body_buffer.size(), content_type);
+				PutRequestInfo info(url, headers, *params, const_data_ptr_cast(body_buffer.c_str()), body_buffer.size(),
+				                    content_type);
 				info.try_request = true;
 				response = client->Put(info);
 				break;
@@ -196,8 +205,7 @@ public:
 				return aws_response;
 			}
 
-			aws_response->SetResponseCode(
-			    static_cast<Aws::Http::HttpResponseCode>(static_cast<int>(response->status)));
+			aws_response->SetResponseCode(static_cast<Aws::Http::HttpResponseCode>(static_cast<int>(response->status)));
 			for (const auto &header : response->headers) {
 				aws_response->AddHeader(header.first.c_str(), header.second.c_str());
 			}
@@ -225,23 +233,29 @@ public:
 
 	std::shared_ptr<Aws::Http::HttpClient>
 	CreateHttpClient(const Aws::Client::ClientConfiguration &config) const override {
-#ifndef __EMSCRIPTEN__
-		// Opt-out (native only): hand back the SDK's own curl transport, exactly as
-		// the default factory would, so behaviour matches a build without this bridge.
+#if AWS_HTTP_SDK_FALLBACK
+		// Opt-out (native only): hand back the SDK's own transport, exactly as the
+		// default factory would, so behaviour matches a build without this bridge.
 		if (!NetworkCallsViaDuckDB(db)) {
+#ifdef _WIN32
+			return Aws::MakeShared<Aws::Http::WinHttpSyncHttpClient>("DuckDBAwsHttp", config);
+#else
 			return Aws::MakeShared<Aws::Http::CurlHttpClient>("DuckDBAwsHttp", config);
+#endif
 		}
 #endif
 		return Aws::MakeShared<DuckDBAwsHttpClient>("DuckDBAwsHttp", db);
 	}
 
-	std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(const Aws::String &uri, Aws::Http::HttpMethod method,
-	                                                          const Aws::IOStreamFactory &streamFactory) const override {
+	std::shared_ptr<Aws::Http::HttpRequest>
+	CreateHttpRequest(const Aws::String &uri, Aws::Http::HttpMethod method,
+	                  const Aws::IOStreamFactory &streamFactory) const override {
 		return CreateHttpRequest(Aws::Http::URI(uri), method, streamFactory);
 	}
 
-	std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(const Aws::Http::URI &uri, Aws::Http::HttpMethod method,
-	                                                          const Aws::IOStreamFactory &streamFactory) const override {
+	std::shared_ptr<Aws::Http::HttpRequest>
+	CreateHttpRequest(const Aws::Http::URI &uri, Aws::Http::HttpMethod method,
+	                  const Aws::IOStreamFactory &streamFactory) const override {
 		auto request = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>("DuckDBAwsHttp", uri, method);
 		request->SetResponseStreamFactory(streamFactory);
 		return request;

--- a/src/aws_http_client.cpp
+++ b/src/aws_http_client.cpp
@@ -1,0 +1,231 @@
+#include "aws_http_client.hpp"
+
+#include "duckdb/common/http_util.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/database.hpp"
+
+#include <aws/core/http/HttpClient.h>
+#include <aws/core/http/HttpClientFactory.h>
+#include <aws/core/http/HttpRequest.h>
+#include <aws/core/http/standard/StandardHttpRequest.h>
+#include <aws/core/http/standard/StandardHttpResponse.h>
+
+#include <sstream>
+
+// Bridge: an aws-sdk-cpp HttpClientFactory whose HttpClient forwards every request
+// to DuckDB's polymorphic HTTPUtil (HTTPUtil::Get(db)). We only ever call the base
+// HTTPUtil virtual methods; the actual transport is whatever the DatabaseInstance
+// has registered (httpfs curl on native, browser fetch under wasm). See
+// aws_http_client.hpp for why this is the extension's HTTP path on all platforms.
+
+namespace duckdb {
+
+namespace {
+
+RequestType ToDuckDBRequestType(Aws::Http::HttpMethod method) {
+	switch (method) {
+	case Aws::Http::HttpMethod::HTTP_GET:
+		return RequestType::GET_REQUEST;
+	case Aws::Http::HttpMethod::HTTP_PUT:
+		return RequestType::PUT_REQUEST;
+	case Aws::Http::HttpMethod::HTTP_HEAD:
+		return RequestType::HEAD_REQUEST;
+	case Aws::Http::HttpMethod::HTTP_DELETE:
+		return RequestType::DELETE_REQUEST;
+	default:
+		// AWS query-protocol services (STS/RDS/Redshift/CloudFormation) issue POST
+		// with a form-urlencoded body; PATCH/OPTIONS also map here as best-effort.
+		return RequestType::POST_REQUEST;
+	}
+}
+
+//! DuckDB's HTTPUtil::DecomposeURL requires a '/' after the authority (it does
+//! url.find('/', 8) and throws "URL needs to contain a '/' after the host"
+//! otherwise). The AWS SDK serializes query-protocol endpoints
+//! (STS/RDS/Redshift/CloudFormation) as a bare host with an empty path, e.g.
+//! "https://cloudformation.us-east-1.amazonaws.com", so add the missing '/'.
+//! SigV4 canonicalizes an empty path to "/" too, so this stays consistent with
+//! what was signed.
+string EnsureUrlHasPath(string url) {
+	auto scheme_pos = url.find("://");
+	idx_t authority_start = (scheme_pos == string::npos) ? 0 : scheme_pos + 3;
+	auto sep_pos = url.find_first_of("/?#", authority_start);
+	if (sep_pos == string::npos) {
+		// "https://host" -> "https://host/"
+		return url + "/";
+	}
+	if (url[sep_pos] != '/') {
+		// "https://host?a=b" -> "https://host/?a=b"
+		url.insert(sep_pos, "/");
+	}
+	return url;
+}
+
+//! Read the AWS request's body stream fully into a string (for POST/PUT).
+string ReadRequestBody(const std::shared_ptr<Aws::Http::HttpRequest> &request) {
+	const auto &body = request->GetContentBody();
+	if (!body) {
+		return string();
+	}
+	// Rewind BEFORE reading. The SDK signs the request by hashing this same stream
+	// (SigV4 payload hash), which leaves the read position at end-of-stream. Reading
+	// from there yields an empty body, so the POST goes out with no form data — e.g.
+	// "Action=ListStacks&Version=2010-05-15" for the query protocol — and AWS replies
+	// <UnknownOperationException/> (no Action to route). Reset again afterwards so any
+	// later consumer still sees the whole body.
+	body->clear();
+	body->seekg(0, std::ios_base::beg);
+	std::stringstream ss;
+	ss << body->rdbuf();
+	body->clear();
+	body->seekg(0, std::ios_base::beg);
+	return ss.str();
+}
+
+class DuckDBAwsHttpClient : public Aws::Http::HttpClient {
+public:
+	explicit DuckDBAwsHttpClient(DatabaseInstance &db_p) : db(db_p) {
+	}
+
+	std::shared_ptr<Aws::Http::HttpResponse>
+	MakeRequest(const std::shared_ptr<Aws::Http::HttpRequest> &request,
+	            Aws::Utils::RateLimits::RateLimiterInterface *, // read limiter unused
+	            Aws::Utils::RateLimits::RateLimiterInterface *) const override { // write limiter unused
+		auto aws_response = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>("DuckDBAwsHttp", request);
+
+		try {
+			auto &http_util = HTTPUtil::Get(db);
+			string url = EnsureUrlHasPath(request->GetUri().GetURIString(true).c_str());
+
+			auto params = http_util.InitializeParameters(db, url);
+
+			HTTPHeaders headers(db);
+			for (const auto &header : request->GetHeaders()) {
+				// The browser forbids scripts from setting these (Fetch "forbidden
+				// header names") and sets them itself — host from the URL, content-length
+				// from the body — logging "Refused to set unsafe header" otherwise. SigV4
+				// signs 'host', but the browser reproduces the same value from the URL, so
+				// the signature still validates. Skip them so the wasm client does not try.
+				auto lower = StringUtil::Lower(header.first.c_str());
+				if (lower == "host" || lower == "content-length") {
+					continue;
+				}
+				headers.Insert(header.first.c_str(), header.second.c_str());
+			}
+
+			string path, proto_host_port;
+			HTTPUtil::DecomposeURL(url, path, proto_host_port);
+			auto client = http_util.InitializeClient(*params, proto_host_port);
+
+			unique_ptr<HTTPResponse> response;
+			string body_buffer; // request body storage kept alive across the call
+
+			switch (ToDuckDBRequestType(request->GetMethod())) {
+			case RequestType::GET_REQUEST: {
+				GetRequestInfo info(
+				    url, headers, *params, [](const HTTPResponse &) { return true; },
+				    [&](const_data_ptr_t data, idx_t len) {
+					    aws_response->GetResponseBody().write(const_char_ptr_cast(data), NumericCast<int64_t>(len));
+					    return true;
+				    });
+				info.try_request = true;
+				response = client->Get(info);
+				break;
+			}
+			case RequestType::POST_REQUEST: {
+				body_buffer = ReadRequestBody(request);
+				PostRequestInfo info(url, headers, *params, const_data_ptr_cast(body_buffer.c_str()),
+				                     body_buffer.size());
+				info.try_request = true;
+				response = client->Post(info);
+				if (response) {
+					aws_response->GetResponseBody().write(info.buffer_out.data(),
+					                                      NumericCast<int64_t>(info.buffer_out.size()));
+				}
+				break;
+			}
+			case RequestType::PUT_REQUEST: {
+				body_buffer = ReadRequestBody(request);
+				string content_type = request->GetContentType().c_str();
+				PutRequestInfo info(url, headers, *params, const_data_ptr_cast(body_buffer.c_str()),
+				                    body_buffer.size(), content_type);
+				info.try_request = true;
+				response = client->Put(info);
+				break;
+			}
+			case RequestType::HEAD_REQUEST: {
+				HeadRequestInfo info(url, headers, *params);
+				info.try_request = true;
+				response = client->Head(info);
+				break;
+			}
+			case RequestType::DELETE_REQUEST: {
+				DeleteRequestInfo info(url, headers, *params);
+				info.try_request = true;
+				response = client->Delete(info);
+				break;
+			}
+			default:
+				break;
+			}
+
+			if (!response) {
+				aws_response->SetResponseCode(Aws::Http::HttpResponseCode::REQUEST_NOT_MADE);
+				return aws_response;
+			}
+
+			aws_response->SetResponseCode(
+			    static_cast<Aws::Http::HttpResponseCode>(static_cast<int>(response->status)));
+			for (const auto &header : response->headers) {
+				aws_response->AddHeader(header.first.c_str(), header.second.c_str());
+			}
+			// For non-GET requests whose body did not stream via a handler, copy it now.
+			if (!response->body.empty()) {
+				aws_response->GetResponseBody().write(response->body.data(),
+				                                      NumericCast<int64_t>(response->body.size()));
+			}
+		} catch (std::exception &ex) {
+			aws_response->SetResponseCode(Aws::Http::HttpResponseCode::REQUEST_NOT_MADE);
+			aws_response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
+			aws_response->SetClientErrorMessage(ex.what());
+		}
+		return aws_response;
+	}
+
+private:
+	DatabaseInstance &db;
+};
+
+class DuckDBAwsHttpClientFactory : public Aws::Http::HttpClientFactory {
+public:
+	explicit DuckDBAwsHttpClientFactory(DatabaseInstance &db_p) : db(db_p) {
+	}
+
+	std::shared_ptr<Aws::Http::HttpClient>
+	CreateHttpClient(const Aws::Client::ClientConfiguration &) const override {
+		return Aws::MakeShared<DuckDBAwsHttpClient>("DuckDBAwsHttp", db);
+	}
+
+	std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(const Aws::String &uri, Aws::Http::HttpMethod method,
+	                                                          const Aws::IOStreamFactory &streamFactory) const override {
+		return CreateHttpRequest(Aws::Http::URI(uri), method, streamFactory);
+	}
+
+	std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(const Aws::Http::URI &uri, Aws::Http::HttpMethod method,
+	                                                          const Aws::IOStreamFactory &streamFactory) const override {
+		auto request = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>("DuckDBAwsHttp", uri, method);
+		request->SetResponseStreamFactory(streamFactory);
+		return request;
+	}
+
+private:
+	DatabaseInstance &db;
+};
+
+} // namespace
+
+void RegisterDuckDBAwsHttpClientFactory(DatabaseInstance &db) {
+	Aws::Http::SetHttpClientFactory(Aws::MakeShared<DuckDBAwsHttpClientFactory>("DuckDBAwsHttp", db));
+}
+
+} // namespace duckdb

--- a/src/aws_http_client.cpp
+++ b/src/aws_http_client.cpp
@@ -318,8 +318,7 @@ public:
 				response_body = std::move(response->body);
 			}
 			if (!response_body.empty()) {
-				aws_response->GetResponseBody().write(response_body.data(),
-				                                      NumericCast<int64_t>(response_body.size()));
+				aws_response->GetResponseBody().write(response_body.data(), NumericCast<int64_t>(response_body.size()));
 			}
 		} catch (std::exception &ex) {
 			aws_response->SetResponseCode(Aws::Http::HttpResponseCode::REQUEST_NOT_MADE);

--- a/src/aws_http_client.cpp
+++ b/src/aws_http_client.cpp
@@ -10,11 +10,9 @@
 #include <aws/core/http/HttpRequest.h>
 #include <aws/core/http/standard/StandardHttpRequest.h>
 #include <aws/core/http/standard/StandardHttpResponse.h>
-// The opt-out path (aws_network_calls_via_duckdb = false) hands back the SDK's
-// own transport, which differs per platform: WinHTTP on Windows, curl elsewhere.
-// The SDK only installs the headers for the transport it was built with, so this
-// selection has to mirror the SDK's own DefaultHttpClientFactory. Under emscripten
-// neither is built, so there the setting is effectively forced on.
+// Mirrors the SDK's DefaultHttpClientFactory: only the transport the SDK was built
+// with has its headers installed. Under emscripten neither exists, so the bridge is
+// the only path there and the opt-out setting is ignored.
 #ifdef __EMSCRIPTEN__
 #define AWS_HTTP_SDK_FALLBACK 0
 #else
@@ -28,23 +26,13 @@
 
 #include <sstream>
 
-// Bridge: an aws-sdk-cpp HttpClientFactory whose HttpClient forwards every request
-// to DuckDB's polymorphic HTTPUtil (HTTPUtil::Get(db)). We only ever call the base
-// HTTPUtil virtual methods; the actual transport is whatever the DatabaseInstance
-// has registered (httpfs curl on native, browser fetch under wasm). See
-// aws_http_client.hpp for why this is the extension's HTTP path on all platforms.
-
 namespace duckdb {
 
-//! The setting that toggles this bridge. Default true: all AWS SDK network calls
-//! go through DuckDB's HTTPUtil. Set false (native only) to fall back to the SDK's
-//! own HTTP transport.
 static constexpr const char *NETWORK_VIA_DUCKDB_SETTING = "aws_network_calls_via_duckdb";
 
 namespace {
 
-//! Read the toggle from the database's current settings. Defaults to true when the
-//! option is unset or unreadable, so the bridge is on unless explicitly disabled.
+//! Defaults to true, so the bridge is on unless explicitly disabled.
 bool NetworkCallsViaDuckDB(DatabaseInstance &db) {
 	Value value;
 	if (db.TryGetCurrentSetting(NETWORK_VIA_DUCKDB_SETTING, value) && !value.IsNull()) {
@@ -64,25 +52,21 @@ RequestType ToDuckDBRequestType(Aws::Http::HttpMethod method) {
 	case Aws::Http::HttpMethod::HTTP_DELETE:
 		return RequestType::DELETE_REQUEST;
 	default:
-		// AWS query-protocol services (STS/RDS/Redshift/CloudFormation) issue POST
-		// with a form-urlencoded body; PATCH/OPTIONS also map here as best-effort.
+		// Query-protocol services (STS/RDS/Redshift/CloudFormation) POST; PATCH/OPTIONS
+		// map here as best-effort.
 		return RequestType::POST_REQUEST;
 	}
 }
 
-//! DuckDB's HTTPUtil::DecomposeURL requires a '/' after the authority (it does
-//! url.find('/', 8) and throws "URL needs to contain a '/' after the host"
-//! otherwise). The AWS SDK serializes query-protocol endpoints
-//! (STS/RDS/Redshift/CloudFormation) as a bare host with an empty path, e.g.
-//! "https://cloudformation.us-east-1.amazonaws.com", so add the missing '/'.
-//! SigV4 canonicalizes an empty path to "/" too, so this stays consistent with
-//! what was signed.
+//! HTTPUtil::DecomposeURL throws unless a '/' follows the authority, but the SDK
+//! serializes query-protocol endpoints as a bare host ("https://cloudformation.
+//! us-east-1.amazonaws.com"). SigV4 canonicalizes an empty path to "/" as well, so
+//! adding it keeps the URL consistent with what was signed.
 string EnsureUrlHasPath(string url) {
 	auto scheme_pos = url.find("://");
 	idx_t authority_start = (scheme_pos == string::npos) ? 0 : scheme_pos + 3;
 	auto sep_pos = url.find_first_of("/?#", authority_start);
 	if (sep_pos == string::npos) {
-		// "https://host" -> "https://host/"
 		return url + "/";
 	}
 	if (url[sep_pos] != '/') {
@@ -92,18 +76,14 @@ string EnsureUrlHasPath(string url) {
 	return url;
 }
 
-//! Read the AWS request's body stream fully into a string (for POST/PUT).
 string ReadRequestBody(const std::shared_ptr<Aws::Http::HttpRequest> &request) {
 	const auto &body = request->GetContentBody();
 	if (!body) {
 		return string();
 	}
-	// Rewind BEFORE reading. The SDK signs the request by hashing this same stream
-	// (SigV4 payload hash), which leaves the read position at end-of-stream. Reading
-	// from there yields an empty body, so the POST goes out with no form data — e.g.
-	// "Action=ListStacks&Version=2010-05-15" for the query protocol — and AWS replies
-	// <UnknownOperationException/> (no Action to route). Reset again afterwards so any
-	// later consumer still sees the whole body.
+	// Rewind BEFORE reading: SigV4 hashes this same stream when signing, leaving it at
+	// end-of-stream. Reading from there sends an empty body and AWS answers
+	// <UnknownOperationException/>. Rewind afterwards too, for any later consumer.
 	body->clear();
 	body->seekg(0, std::ios_base::beg);
 	std::stringstream ss;
@@ -132,11 +112,9 @@ public:
 
 			HTTPHeaders headers(db);
 			for (const auto &header : request->GetHeaders()) {
-				// The browser forbids scripts from setting these (Fetch "forbidden
-				// header names") and sets them itself — host from the URL, content-length
-				// from the body — logging "Refused to set unsafe header" otherwise. SigV4
-				// signs 'host', but the browser reproduces the same value from the URL, so
-				// the signature still validates. Skip them so the wasm client does not try.
+				// Fetch forbids scripts from setting these and derives them itself (host
+				// from the URL, content-length from the body). SigV4 signs 'host', but the
+				// browser reproduces the same value, so the signature still validates.
 				auto lower = StringUtil::Lower(header.first.c_str());
 				if (lower == "host" || lower == "content-length") {
 					continue;
@@ -234,8 +212,7 @@ public:
 	std::shared_ptr<Aws::Http::HttpClient>
 	CreateHttpClient(const Aws::Client::ClientConfiguration &config) const override {
 #if AWS_HTTP_SDK_FALLBACK
-		// Opt-out (native only): hand back the SDK's own transport, exactly as the
-		// default factory would, so behaviour matches a build without this bridge.
+		// Opt-out (native only): behave exactly as the SDK's default factory would.
 		if (!NetworkCallsViaDuckDB(db)) {
 #ifdef _WIN32
 			return Aws::MakeShared<Aws::Http::WinHttpSyncHttpClient>("DuckDBAwsHttp", config);

--- a/src/aws_http_client.cpp
+++ b/src/aws_http_client.cpp
@@ -163,11 +163,7 @@ string ReadRequestBody(const std::shared_ptr<Aws::Http::HttpRequest> &request) {
 
 class DuckDBAwsHttpClient : public Aws::Http::HttpClient {
 public:
-	DuckDBAwsHttpClient(weak_ptr<DatabaseInstance> db_p, const Aws::Client::ClientConfiguration &config)
-	    : db(std::move(db_p)), request_timeout_ms(config.requestTimeoutMs), verify_ssl(config.verifySSL),
-	      follow_redirects(config.followRedirects != Aws::Client::FollowRedirectsPolicy::NEVER),
-	      proxy_host(config.proxyHost.c_str()), proxy_port(config.proxyPort),
-	      proxy_username(config.proxyUserName.c_str()), proxy_password(config.proxyPassword.c_str()) {
+	explicit DuckDBAwsHttpClient(weak_ptr<DatabaseInstance> db_p) : db(std::move(db_p)) {
 	}
 
 	std::shared_ptr<Aws::Http::HttpResponse>
@@ -202,7 +198,6 @@ public:
 			if (!params->logger) {
 				params->logger = db_instance->GetLogManager().GlobalLoggerReference();
 			}
-			ApplyClientConfig(*params);
 
 			HTTPHeaders headers(*db_instance);
 			for (const auto &header : request->GetHeaders()) {
@@ -323,37 +318,7 @@ public:
 	}
 
 private:
-	//! Carry over the parts of the SDK's ClientConfiguration that HTTPParams can express.
-	//! connectTimeoutMs and caFile/caPath have no equivalent: the transport's own CA store
-	//! and DuckDB's http settings govern those on this path.
-	void ApplyClientConfig(HTTPParams &params) const {
-		if (request_timeout_ms > 0) {
-			auto timeout_ms = NumericCast<uint64_t>(request_timeout_ms);
-			params.timeout = timeout_ms / 1000;
-			params.timeout_usec = (timeout_ms % 1000) * 1000;
-		}
-		params.follow_location = follow_redirects;
-		if (!verify_ssl) {
-			params.override_verify_ssl = true;
-			params.verify_ssl = false;
-		}
-		if (!proxy_host.empty()) {
-			params.http_proxy = proxy_host;
-			params.http_proxy_port = proxy_port;
-			params.http_proxy_username = proxy_username;
-			params.http_proxy_password = proxy_password;
-		}
-	}
-
-private:
 	weak_ptr<DatabaseInstance> db;
-	long request_timeout_ms;
-	bool verify_ssl;
-	bool follow_redirects;
-	string proxy_host;
-	idx_t proxy_port;
-	string proxy_username;
-	string proxy_password;
 };
 
 class DuckDBAwsHttpClientFactory : public Aws::Http::HttpClientFactory {
@@ -388,8 +353,17 @@ public:
 			return Aws::MakeShared<Aws::Http::WinHttpSyncHttpClient>("DuckDBAwsHttp", config);
 #endif
 		}
+#else
+		(void)config;
 #endif
-		return Aws::MakeShared<DuckDBAwsHttpClient>("DuckDBAwsHttp", db, config);
+		// The bridge deliberately ignores ClientConfiguration. Every config in this extension
+		// comes from BuildClientConfigWithCa(), i.e. SDK defaults plus a caFile detected for
+		// the SDK's statically linked curl -- none of it is user intent expressed through
+		// DuckDB. On this path the transport is httpfs, which owns its own CA store, timeouts
+		// and proxy, configured by DuckDB's http settings. Forwarding the SDK's values would
+		// override those with defaults nobody asked for (its requestTimeoutMs of 3000 would
+		// cut DuckDB's 30s timeout to 3s) and point TLS at a CA path we guessed.
+		return Aws::MakeShared<DuckDBAwsHttpClient>("DuckDBAwsHttp", db);
 	}
 
 	std::shared_ptr<Aws::Http::HttpRequest>

--- a/src/aws_http_client.cpp
+++ b/src/aws_http_client.cpp
@@ -1,29 +1,45 @@
 #include "aws_http_client.hpp"
 
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/http_util.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/logging/log_manager.hpp"
+#include "duckdb/main/extension_helper.hpp"
 
+#include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/http/HttpClient.h>
 #include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/http/HttpRequest.h>
+#include <aws/core/http/HttpTypes.h>
 #include <aws/core/http/standard/StandardHttpRequest.h>
 #include <aws/core/http/standard/StandardHttpResponse.h>
-// Mirrors the SDK's DefaultHttpClientFactory: only the transport the SDK was built
-// with has its headers installed. Under emscripten neither exists, so the bridge is
-// the only path there and the opt-out setting is ignored.
-#ifdef __EMSCRIPTEN__
-#define AWS_HTTP_SDK_FALLBACK 0
-#else
-#define AWS_HTTP_SDK_FALLBACK 1
-#ifdef _WIN32
+
+// The opt-out path hands back the SDK's own transport, and which one that is depends on how
+// the SDK was built rather than on the host OS: a Windows SDK built with FORCE_CURL uses
+// curl, and keying this on _WIN32 would leave WinHttpSyncHttpClient unresolved at link time.
+// The SDK's own selection macros (ENABLE_CURL_CLIENT etc.) are not exported to consumers,
+// but it installs only the headers for the transport it was compiled with, so probe for
+// those. Where neither is present (emscripten) the bridge is the only path and the setting
+// is ignored.
+#if defined(__EMSCRIPTEN__)
+#define AWS_HTTP_SDK_FALLBACK      0
+#define AWS_HTTP_SDK_FALLBACK_CURL 0
+#elif defined(_WIN32) && __has_include(<aws/core/http/windows/WinHttpSyncHttpClient.h>)
+#define AWS_HTTP_SDK_FALLBACK      1
+#define AWS_HTTP_SDK_FALLBACK_CURL 0
 #include <aws/core/http/windows/WinHttpSyncHttpClient.h>
-#else
+#elif __has_include(<aws/core/http/curl/CurlHttpClient.h>)
+#define AWS_HTTP_SDK_FALLBACK      1
+#define AWS_HTTP_SDK_FALLBACK_CURL 1
 #include <aws/core/http/curl/CurlHttpClient.h>
-#endif
+#else
+#define AWS_HTTP_SDK_FALLBACK      0
+#define AWS_HTTP_SDK_FALLBACK_CURL 0
 #endif
 
+#include <atomic>
 #include <sstream>
 
 namespace duckdb {
@@ -32,7 +48,9 @@ static constexpr const char *NETWORK_VIA_DUCKDB_SETTING = "aws_network_calls_via
 
 namespace {
 
-//! Defaults to true, so the bridge is on unless explicitly disabled.
+//! Defaults to true, so the bridge is on unless explicitly disabled. Registered as a
+//! GLOBAL-scoped option, since this is read off the DatabaseInstance rather than a
+//! ClientContext and a session-scoped value would never be seen here.
 bool NetworkCallsViaDuckDB(DatabaseInstance &db) {
 	Value value;
 	if (db.TryGetCurrentSetting(NETWORK_VIA_DUCKDB_SETTING, value) && !value.IsNull()) {
@@ -41,21 +59,71 @@ bool NetworkCallsViaDuckDB(DatabaseInstance &db) {
 	return true;
 }
 
-RequestType ToDuckDBRequestType(Aws::Http::HttpMethod method) {
+#if AWS_HTTP_SDK_FALLBACK_CURL
+std::atomic<bool> curl_global_initialized {false};
+
+//! Aws::Http::SetHttpClientFactory() calls CleanupHttp(), which tears down curl's global
+//! state through the default factory, and nothing ever re-initializes it: a later
+//! Aws::InitAPI() finds a non-null factory and only calls our InitStaticState(). So the
+//! fallback client has to bring curl back up itself before the first curl_easy_init().
+void EnsureCurlGlobalState() {
+	bool expected = false;
+	if (curl_global_initialized.compare_exchange_strong(expected, true)) {
+		Aws::Http::CurlHttpClient::InitGlobalState();
+	}
+}
+#endif
+
+bool TryGetRequestType(Aws::Http::HttpMethod method, RequestType &result) {
 	switch (method) {
 	case Aws::Http::HttpMethod::HTTP_GET:
-		return RequestType::GET_REQUEST;
+		result = RequestType::GET_REQUEST;
+		return true;
 	case Aws::Http::HttpMethod::HTTP_PUT:
-		return RequestType::PUT_REQUEST;
+		result = RequestType::PUT_REQUEST;
+		return true;
 	case Aws::Http::HttpMethod::HTTP_HEAD:
-		return RequestType::HEAD_REQUEST;
+		result = RequestType::HEAD_REQUEST;
+		return true;
 	case Aws::Http::HttpMethod::HTTP_DELETE:
-		return RequestType::DELETE_REQUEST;
+		result = RequestType::DELETE_REQUEST;
+		return true;
+	case Aws::Http::HttpMethod::HTTP_POST:
+		result = RequestType::POST_REQUEST;
+		return true;
+	case Aws::Http::HttpMethod::HTTP_OPTIONS:
+		result = RequestType::OPTIONS_REQUEST;
+		return true;
 	default:
-		// Query-protocol services (STS/RDS/Redshift/CloudFormation) POST; PATCH/OPTIONS
-		// map here as best-effort.
-		return RequestType::POST_REQUEST;
+		// PATCH has no HTTPUtil equivalent. Refuse it rather than silently issuing it as a
+		// POST, which a server would act on with different semantics.
+		return false;
 	}
+}
+
+//! Core HTTPUtil implements only GET; Put/Head/Delete/Post all throw NotImplemented. Every
+//! AWS call this extension makes is a POST, so an httpfs-provided transport is required.
+//! Auto-load it rather than surfacing an opaque "POST request not implemented".
+HTTPUtil &GetTransport(DatabaseInstance &db) {
+	auto &http_util = HTTPUtil::Get(db);
+	if (http_util.GetName() != "Built-In") {
+		return http_util;
+	}
+	if (ExtensionHelper::TryAutoLoadExtension(db, "httpfs")) {
+		auto &loaded = HTTPUtil::Get(db);
+		if (loaded.GetName() != "Built-In") {
+			return loaded;
+		}
+	}
+	throw InvalidConfigurationException(
+	    "AWS network calls are routed through DuckDB's HTTP layer, which only supports GET without the httpfs "
+	    "extension. Run 'INSTALL httpfs; LOAD httpfs;'"
+#if AWS_HTTP_SDK_FALLBACK
+	    ", or 'SET GLOBAL %s = false' to use the AWS SDK's own HTTP client",
+	    NETWORK_VIA_DUCKDB_SETTING);
+#else
+	);
+#endif
 }
 
 //! HTTPUtil::DecomposeURL throws unless a '/' follows the authority, but the SDK
@@ -95,7 +163,11 @@ string ReadRequestBody(const std::shared_ptr<Aws::Http::HttpRequest> &request) {
 
 class DuckDBAwsHttpClient : public Aws::Http::HttpClient {
 public:
-	explicit DuckDBAwsHttpClient(DatabaseInstance &db_p) : db(db_p) {
+	DuckDBAwsHttpClient(weak_ptr<DatabaseInstance> db_p, const Aws::Client::ClientConfiguration &config)
+	    : db(std::move(db_p)), request_timeout_ms(config.requestTimeoutMs), verify_ssl(config.verifySSL),
+	      follow_redirects(config.followRedirects != Aws::Client::FollowRedirectsPolicy::NEVER),
+	      proxy_host(config.proxyHost.c_str()), proxy_port(config.proxyPort),
+	      proxy_username(config.proxyUserName.c_str()), proxy_password(config.proxyPassword.c_str()) {
 	}
 
 	std::shared_ptr<Aws::Http::HttpResponse>
@@ -105,40 +177,70 @@ public:
 		auto aws_response = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>("DuckDBAwsHttp", request);
 
 		try {
-			auto &http_util = HTTPUtil::Get(db);
+			// The AWS client factory is process-global, so this outlives the instance it was
+			// registered for. Fail cleanly instead of using a destroyed DatabaseInstance.
+			auto db_instance = db.lock();
+			if (!db_instance) {
+				throw InvalidConfigurationException(
+				    "The DuckDB instance this AWS client was created for has been closed");
+			}
+
+			RequestType request_type;
+			if (!TryGetRequestType(request->GetMethod(), request_type)) {
+				throw NotImplementedException(
+				    "HTTP method %s is not supported when AWS network calls are routed through DuckDB's HTTP layer",
+				    Aws::Http::HttpMethodMapper::GetNameForHttpMethod(request->GetMethod()));
+			}
+
+			auto &http_util = GetTransport(*db_instance);
 			string url = EnsureUrlHasPath(request->GetUri().GetURIString(true).c_str());
 
-			auto params = http_util.InitializeParameters(db, url);
+			auto params = http_util.InitializeParameters(*db_instance, url);
+			// HTTPParams only picks up a logger from a ClientContext, and there is none here:
+			// the SDK creates its HTTP client per AWS client, not per query. Attach the
+			// database-wide logger so these requests still show up in duckdb_logs.
+			if (!params->logger) {
+				params->logger = db_instance->GetLogManager().GlobalLoggerReference();
+			}
+			ApplyClientConfig(*params);
 
-			HTTPHeaders headers(db);
+			HTTPHeaders headers(*db_instance);
 			for (const auto &header : request->GetHeaders()) {
-				// Fetch forbids scripts from setting these and derives them itself (host
-				// from the URL, content-length from the body). SigV4 signs 'host', but the
-				// browser reproduces the same value, so the signature still validates.
+				// Fetch forbids scripts from setting these and derives them itself (host from
+				// the URL, content-length from the body). SigV4 signs 'host', but the browser
+				// reproduces the same value, so the signature still validates.
 				auto lower = StringUtil::Lower(header.first.c_str());
 				if (lower == "host" || lower == "content-length") {
 					continue;
 				}
-				headers.Insert(header.first.c_str(), header.second.c_str());
+				// Assign rather than Insert(): HTTPHeaders pre-seeds DuckDB's User-Agent and
+				// Insert() does not overwrite, which would drop the SDK's own user-agent.
+				headers[header.first.c_str()] = header.second.c_str();
 			}
 
-			string path, proto_host_port;
-			HTTPUtil::DecomposeURL(url, path, proto_host_port);
-			auto client = http_util.InitializeClient(*params, proto_host_port);
-
+			unique_ptr<HTTPClient> client;
 			unique_ptr<HTTPResponse> response;
-			string body_buffer; // request body storage kept alive across the call
+			string body_buffer;   // request body storage, kept alive across the call
+			string response_body; // collected once, then written to the SDK response below
 
-			switch (ToDuckDBRequestType(request->GetMethod())) {
+			// Going through HTTPUtil::Request (rather than calling client->Get/Post/... directly)
+			// is what activates try_request, RunRequestWithRetry's backoff and LogRequest, and it
+			// initializes the client for us, including the null-transport check.
+			switch (request_type) {
 			case RequestType::GET_REQUEST: {
 				GetRequestInfo info(
-				    url, headers, *params, [](const HTTPResponse &) { return true; },
+				    url, headers, *params,
+				    [&](const HTTPResponse &) {
+					    // Reset per attempt: a retry replays the content handler from the start.
+					    response_body.clear();
+					    return true;
+				    },
 				    [&](const_data_ptr_t data, idx_t len) {
-					    aws_response->GetResponseBody().write(const_char_ptr_cast(data), NumericCast<int64_t>(len));
+					    response_body.append(const_char_ptr_cast(data), len);
 					    return true;
 				    });
 				info.try_request = true;
-				response = client->Get(info);
+				response = http_util.Request(info, client);
 				break;
 			}
 			case RequestType::POST_REQUEST: {
@@ -146,11 +248,10 @@ public:
 				PostRequestInfo info(url, headers, *params, const_data_ptr_cast(body_buffer.c_str()),
 				                     body_buffer.size());
 				info.try_request = true;
-				response = client->Post(info);
-				if (response) {
-					aws_response->GetResponseBody().write(info.buffer_out.data(),
-					                                      NumericCast<int64_t>(info.buffer_out.size()));
-				}
+				response = http_util.Request(info, client);
+				// POST is the one method that buffers into buffer_out; the transports fill both
+				// this and response->body, so take exactly one of them.
+				response_body = std::move(info.buffer_out);
 				break;
 			}
 			case RequestType::PUT_REQUEST: {
@@ -159,27 +260,46 @@ public:
 				PutRequestInfo info(url, headers, *params, const_data_ptr_cast(body_buffer.c_str()), body_buffer.size(),
 				                    content_type);
 				info.try_request = true;
-				response = client->Put(info);
+				response = http_util.Request(info, client);
 				break;
 			}
 			case RequestType::HEAD_REQUEST: {
 				HeadRequestInfo info(url, headers, *params);
 				info.try_request = true;
-				response = client->Head(info);
+				response = http_util.Request(info, client);
 				break;
 			}
 			case RequestType::DELETE_REQUEST: {
 				DeleteRequestInfo info(url, headers, *params);
 				info.try_request = true;
-				response = client->Delete(info);
+				response = http_util.Request(info, client);
 				break;
 			}
-			default:
+			default: {
+				OptionsRequestInfo info(url, headers, *params);
+				info.try_request = true;
+				response = http_util.Request(info, client);
 				break;
 			}
+			}
+
+			// Hand the client back so httpfs can put the connection in its cache.
+			http_util.CloseClient(std::move(client));
 
 			if (!response) {
 				aws_response->SetResponseCode(Aws::Http::HttpResponseCode::REQUEST_NOT_MADE);
+				aws_response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
+				aws_response->SetClientErrorMessage("No response received");
+				return aws_response;
+			}
+			if (response->status == HTTPStatusCode::INVALID) {
+				// No HTTP status came back at all: a connect/DNS/TLS failure, which try_request
+				// returns as a response carrying request_error instead of throwing. Report it as
+				// REQUEST_NOT_MADE with the message, so the SDK sees a retryable network error
+				// rather than an unknown status 0 with no explanation.
+				aws_response->SetResponseCode(Aws::Http::HttpResponseCode::REQUEST_NOT_MADE);
+				aws_response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
+				aws_response->SetClientErrorMessage(response->GetError().c_str());
 				return aws_response;
 			}
 
@@ -187,10 +307,12 @@ public:
 			for (const auto &header : response->headers) {
 				aws_response->AddHeader(header.first.c_str(), header.second.c_str());
 			}
-			// For non-GET requests whose body did not stream via a handler, copy it now.
-			if (!response->body.empty()) {
-				aws_response->GetResponseBody().write(response->body.data(),
-				                                      NumericCast<int64_t>(response->body.size()));
+			if (response_body.empty()) {
+				response_body = std::move(response->body);
+			}
+			if (!response_body.empty()) {
+				aws_response->GetResponseBody().write(response_body.data(),
+				                                      NumericCast<int64_t>(response_body.size()));
 			}
 		} catch (std::exception &ex) {
 			aws_response->SetResponseCode(Aws::Http::HttpResponseCode::REQUEST_NOT_MADE);
@@ -201,27 +323,73 @@ public:
 	}
 
 private:
-	DatabaseInstance &db;
+	//! Carry over the parts of the SDK's ClientConfiguration that HTTPParams can express.
+	//! connectTimeoutMs and caFile/caPath have no equivalent: the transport's own CA store
+	//! and DuckDB's http settings govern those on this path.
+	void ApplyClientConfig(HTTPParams &params) const {
+		if (request_timeout_ms > 0) {
+			auto timeout_ms = NumericCast<uint64_t>(request_timeout_ms);
+			params.timeout = timeout_ms / 1000;
+			params.timeout_usec = (timeout_ms % 1000) * 1000;
+		}
+		params.follow_location = follow_redirects;
+		if (!verify_ssl) {
+			params.override_verify_ssl = true;
+			params.verify_ssl = false;
+		}
+		if (!proxy_host.empty()) {
+			params.http_proxy = proxy_host;
+			params.http_proxy_port = proxy_port;
+			params.http_proxy_username = proxy_username;
+			params.http_proxy_password = proxy_password;
+		}
+	}
+
+private:
+	weak_ptr<DatabaseInstance> db;
+	long request_timeout_ms;
+	bool verify_ssl;
+	bool follow_redirects;
+	string proxy_host;
+	idx_t proxy_port;
+	string proxy_username;
+	string proxy_password;
 };
 
 class DuckDBAwsHttpClientFactory : public Aws::Http::HttpClientFactory {
 public:
-	explicit DuckDBAwsHttpClientFactory(DatabaseInstance &db_p) : db(db_p) {
+	explicit DuckDBAwsHttpClientFactory(weak_ptr<DatabaseInstance> db_p) : db(std::move(db_p)) {
+	}
+
+	void InitStaticState() override {
+#if AWS_HTTP_SDK_FALLBACK_CURL
+		EnsureCurlGlobalState();
+#endif
+	}
+
+	void CleanupStaticState() override {
+#if AWS_HTTP_SDK_FALLBACK_CURL
+		if (curl_global_initialized.exchange(false)) {
+			Aws::Http::CurlHttpClient::CleanupGlobalState();
+		}
+#endif
 	}
 
 	std::shared_ptr<Aws::Http::HttpClient>
 	CreateHttpClient(const Aws::Client::ClientConfiguration &config) const override {
 #if AWS_HTTP_SDK_FALLBACK
-		// Opt-out (native only): behave exactly as the SDK's default factory would.
-		if (!NetworkCallsViaDuckDB(db)) {
-#ifdef _WIN32
-			return Aws::MakeShared<Aws::Http::WinHttpSyncHttpClient>("DuckDBAwsHttp", config);
-#else
+		auto db_instance = db.lock();
+		if (db_instance && !NetworkCallsViaDuckDB(*db_instance)) {
+			// Opt-out (native only): behave exactly as the SDK's default factory would.
+#if AWS_HTTP_SDK_FALLBACK_CURL
+			EnsureCurlGlobalState();
 			return Aws::MakeShared<Aws::Http::CurlHttpClient>("DuckDBAwsHttp", config);
+#else
+			return Aws::MakeShared<Aws::Http::WinHttpSyncHttpClient>("DuckDBAwsHttp", config);
 #endif
 		}
 #endif
-		return Aws::MakeShared<DuckDBAwsHttpClient>("DuckDBAwsHttp", db);
+		return Aws::MakeShared<DuckDBAwsHttpClient>("DuckDBAwsHttp", db, config);
 	}
 
 	std::shared_ptr<Aws::Http::HttpRequest>
@@ -239,13 +407,17 @@ public:
 	}
 
 private:
-	DatabaseInstance &db;
+	weak_ptr<DatabaseInstance> db;
 };
 
 } // namespace
 
 void RegisterDuckDBAwsHttpClientFactory(DatabaseInstance &db) {
-	Aws::Http::SetHttpClientFactory(Aws::MakeShared<DuckDBAwsHttpClientFactory>("DuckDBAwsHttp", db));
+	// NOTE: Aws::Http::SetHttpClientFactory is process-global, so with several DatabaseInstances
+	// in one process the last LOAD wins and all AWS traffic follows that instance's HTTP
+	// settings. The weak_ptr keeps that from becoming a use-after-free when it is closed.
+	weak_ptr<DatabaseInstance> weak_db = db.shared_from_this();
+	Aws::Http::SetHttpClientFactory(Aws::MakeShared<DuckDBAwsHttpClientFactory>("DuckDBAwsHttp", weak_db));
 }
 
 } // namespace duckdb

--- a/src/aws_http_client.cpp
+++ b/src/aws_http_client.cpp
@@ -46,6 +46,18 @@ namespace duckdb {
 
 static constexpr const char *NETWORK_VIA_DUCKDB_SETTING = "aws_network_calls_via_duckdb";
 
+//! Set by AwsInstanceBinding for the duration of an operation, so the process-global
+//! factory can tell which DatabaseInstance an AWS client is being built for.
+static thread_local weak_ptr<DatabaseInstance> bound_instance;
+
+AwsInstanceBinding::AwsInstanceBinding(DatabaseInstance &db) : previous(bound_instance) {
+	bound_instance = weak_ptr<DatabaseInstance>(db.shared_from_this());
+}
+
+AwsInstanceBinding::~AwsInstanceBinding() {
+	bound_instance = previous;
+}
+
 namespace {
 
 //! Defaults to true, so the bridge is on unless explicitly disabled. Registered as a
@@ -340,10 +352,21 @@ public:
 #endif
 	}
 
+	//! Prefer the instance bound for this operation; fall back to the one that registered
+	//! this factory, which is all we have for AWS clients built outside any binding (the
+	//! SDK's own internal clients, say).
+	weak_ptr<DatabaseInstance> ResolveInstance() const {
+		if (!bound_instance.expired()) {
+			return bound_instance;
+		}
+		return db;
+	}
+
 	std::shared_ptr<Aws::Http::HttpClient>
 	CreateHttpClient(const Aws::Client::ClientConfiguration &config) const override {
+		auto resolved = ResolveInstance();
 #if AWS_HTTP_SDK_FALLBACK
-		auto db_instance = db.lock();
+		auto db_instance = resolved.lock();
 		if (db_instance && !NetworkCallsViaDuckDB(*db_instance)) {
 			// Opt-out (native only): behave exactly as the SDK's default factory would.
 #if AWS_HTTP_SDK_FALLBACK_CURL
@@ -363,7 +386,7 @@ public:
 		// and proxy, configured by DuckDB's http settings. Forwarding the SDK's values would
 		// override those with defaults nobody asked for (its requestTimeoutMs of 3000 would
 		// cut DuckDB's 30s timeout to 3s) and point TLS at a CA path we guessed.
-		return Aws::MakeShared<DuckDBAwsHttpClient>("DuckDBAwsHttp", db);
+		return Aws::MakeShared<DuckDBAwsHttpClient>("DuckDBAwsHttp", resolved);
 	}
 
 	std::shared_ptr<Aws::Http::HttpRequest>

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -1,3 +1,5 @@
+#include "aws_http_client.hpp"
+#include "duckdb/main/database.hpp"
 #include "aws_secret.hpp"
 #include "aws_client.hpp"
 #include "utils/utils.hpp"
@@ -345,6 +347,7 @@ CreateRDSSecretWithProvider(std::shared_ptr<DuckDBCustomAWSCredentialsProviderCh
 
 //! This is the actual callback function
 static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &context, CreateSecretInput &input) {
+	AwsInstanceBinding aws_binding(DatabaseInstance::GetDatabase(context));
 	Aws::Auth::AWSCredentials credentials;
 
 	string profile = TryGetStringParam(input, "profile");

--- a/src/cloudformation_functions.cpp
+++ b/src/cloudformation_functions.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/common/types/uuid.hpp"
 #include "duckdb/function/function_set.hpp"
 #include "duckdb/function/scalar_function.hpp"
+#include "aws_http_client.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/parallel/task_executor.hpp"
@@ -358,6 +359,7 @@ ResolvedStackRequest ResolveStackRequest(Aws::CloudFormation::CloudFormationClie
 } // namespace
 
 static void CloudFormationCreateStackFun(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	AwsInstanceBinding aws_binding(DatabaseInstance::GetDatabase(context));
 	auto &data = (CloudFormationCreateStackBindData &)*data_p.bind_data;
 	if (data.finished) {
 		return;
@@ -525,6 +527,7 @@ static unique_ptr<FunctionData> CloudFormationDescribeStackBind(ClientContext &c
 }
 
 static void CloudFormationDescribeStackFun(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	AwsInstanceBinding aws_binding(DatabaseInstance::GetDatabase(context));
 	auto &data = (CloudFormationDescribeStackBindData &)*data_p.bind_data;
 	if (data.finished) {
 		return;
@@ -634,6 +637,7 @@ static unique_ptr<FunctionData> CloudFormationDeleteStackBind(ClientContext &con
 }
 
 static void CloudFormationDeleteStackFun(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	AwsInstanceBinding aws_binding(DatabaseInstance::GetDatabase(context));
 	auto &data = (CloudFormationDeleteStackBindData &)*data_p.bind_data;
 	if (data.finished) {
 		return;
@@ -788,6 +792,7 @@ static unique_ptr<FunctionData> CloudFormationListStacksBind(ClientContext &cont
 }
 
 static void CloudFormationListStacksFun(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	AwsInstanceBinding aws_binding(DatabaseInstance::GetDatabase(context));
 	auto &data = (CloudFormationListStacksBindData &)*data_p.bind_data;
 
 	if (!data.initialized) {
@@ -882,7 +887,11 @@ struct CloudFormationDescribeStacksRow {
 };
 
 // Fetch all stacks in one region (paginated), appending to `out`. Throws on AWS error.
-static void DescribeRegionStacks(const string &region, vector<CloudFormationDescribeStacksRow> &out) {
+static void DescribeRegionStacks(DatabaseInstance &db, const string &region,
+                                 vector<CloudFormationDescribeStacksRow> &out) {
+	// Runs as a scheduler task on another thread, where the thread-local binding set by the
+	// table function does not reach, so establish one here.
+	AwsInstanceBinding aws_binding(db);
 	auto provider = BuildAwsCredentialsProvider("", /*require_credentials=*/true);
 	auto cfg = BuildClientConfigWithCa();
 	cfg.region = region.c_str();
@@ -944,12 +953,13 @@ static void DescribeRegionStacks(const string &region, vector<CloudFormationDesc
 // abort the whole sweep via WorkOnTasks) and replaces its slot with a single 'error' sentinel row, so
 // a dead region is surfaced-but-not-fatal instead of silently vanishing.
 struct DescribeRegionTask : public BaseExecutorTask {
-	DescribeRegionTask(TaskExecutor &executor, string region_p, vector<CloudFormationDescribeStacksRow> &slot_p)
-	    : BaseExecutorTask(executor), region(std::move(region_p)), slot(slot_p) {
+	DescribeRegionTask(TaskExecutor &executor, DatabaseInstance &db_p, string region_p,
+	                   vector<CloudFormationDescribeStacksRow> &slot_p)
+	    : BaseExecutorTask(executor), db(db_p), region(std::move(region_p)), slot(slot_p) {
 	}
 	void ExecuteTask() override {
 		try {
-			DescribeRegionStacks(region, slot);
+			DescribeRegionStacks(db, region, slot);
 		} catch (const std::exception &e) {
 			EmitError(e.what());
 		} catch (...) {
@@ -965,6 +975,7 @@ struct DescribeRegionTask : public BaseExecutorTask {
 		err.outputs = Value(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)); // NULL
 		slot.push_back(std::move(err));
 	}
+	DatabaseInstance &db;
 	string region;
 	vector<CloudFormationDescribeStacksRow> &slot;
 };
@@ -1042,19 +1053,21 @@ static unique_ptr<FunctionData> CloudFormationDescribeStacksBind(ClientContext &
 }
 
 static void CloudFormationDescribeStacksFun(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	AwsInstanceBinding aws_binding(DatabaseInstance::GetDatabase(context));
 	auto &data = (CloudFormationDescribeStacksBindData &)*data_p.bind_data;
 
 	if (!data.initialized) {
 		if (data.throw_on_region_error) {
 			// Single explicit region: run inline and let its error propagate.
-			DescribeRegionStacks(data.regions[0], data.rows);
+			DescribeRegionStacks(DatabaseInstance::GetDatabase(context), data.regions[0], data.rows);
 		} else {
 			// Parallel fan-out: one task per region into its own slot; a region that errors is skipped. Fixed-size
 			// `slots` so the vector never reallocates while tasks hold references into it.
 			vector<vector<CloudFormationDescribeStacksRow>> slots(data.regions.size());
 			TaskExecutor executor(context);
 			for (idx_t i = 0; i < data.regions.size(); i++) {
-				executor.ScheduleTask(make_uniq<DescribeRegionTask>(executor, data.regions[i], slots[i]));
+				executor.ScheduleTask(make_uniq<DescribeRegionTask>(executor, DatabaseInstance::GetDatabase(context),
+				                                                    data.regions[i], slots[i]));
 			}
 			executor.WorkOnTasks();
 			for (auto &slot : slots) {

--- a/src/include/aws_http_client.hpp
+++ b/src/include/aws_http_client.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace duckdb {
+class DatabaseInstance;
+
+//! Install an AWS SDK HttpClientFactory that routes ALL AWS SDK HTTP through
+//! DuckDB's HTTPUtil (obtained from the DatabaseInstance). The concrete transport
+//! is whatever is registered on the instance: httpfs's curl-backed HTTPFSUtil on
+//! native, the browser-fetch HTTP layer under duckdb-wasm. This is what lets the
+//! extension build for wasm (no libcurl dependency) and unifies HTTP handling
+//! (proxy, CA certs, logging) on every platform. Call once at extension load,
+//! BEFORE any AWS client is constructed (i.e. right after Aws::InitAPI).
+void RegisterDuckDBAwsHttpClientFactory(DatabaseInstance &db);
+
+} // namespace duckdb

--- a/src/include/aws_http_client.hpp
+++ b/src/include/aws_http_client.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "duckdb/common/shared_ptr.hpp"
+
 namespace duckdb {
 class DatabaseInstance;
 
@@ -9,5 +11,29 @@ class DatabaseInstance;
 //! libcurl, and unifies proxy, CA certs and logging everywhere. Call once at
 //! extension load, BEFORE any AWS client is constructed.
 void RegisterDuckDBAwsHttpClientFactory(DatabaseInstance &db);
+
+//! Binds AWS SDK client construction on the current thread to a DatabaseInstance.
+//!
+//! Aws::Http::SetHttpClientFactory is process-global and CreateHttpClient() is handed
+//! nothing but a ClientConfiguration, so the factory cannot tell which instance an AWS
+//! client belongs to. Without a binding it falls back to whichever instance most
+//! recently loaded the extension, which means that with several DatabaseInstances in
+//! one process every instance's AWS traffic follows the last-loaded one's transport and
+//! settings -- and breaks outright once that instance is closed.
+//!
+//! Hold one of these across the construction of any AWS SDK client (or across a whole
+//! operation, so clients built underneath it, credential providers included, inherit
+//! it). The binding is thread-local and does NOT propagate to scheduler tasks: a task
+//! that builds its own AWS client has to establish its own.
+class AwsInstanceBinding {
+public:
+	explicit AwsInstanceBinding(DatabaseInstance &db);
+	~AwsInstanceBinding();
+	AwsInstanceBinding(const AwsInstanceBinding &) = delete;
+	AwsInstanceBinding &operator=(const AwsInstanceBinding &) = delete;
+
+private:
+	weak_ptr<DatabaseInstance> previous;
+};
 
 } // namespace duckdb

--- a/src/include/aws_http_client.hpp
+++ b/src/include/aws_http_client.hpp
@@ -3,13 +3,11 @@
 namespace duckdb {
 class DatabaseInstance;
 
-//! Install an AWS SDK HttpClientFactory that routes ALL AWS SDK HTTP through
-//! DuckDB's HTTPUtil (obtained from the DatabaseInstance). The concrete transport
-//! is whatever is registered on the instance: httpfs's curl-backed HTTPFSUtil on
-//! native, the browser-fetch HTTP layer under duckdb-wasm. This is what lets the
-//! extension build for wasm (no libcurl dependency) and unifies HTTP handling
-//! (proxy, CA certs, logging) on every platform. Call once at extension load,
-//! BEFORE any AWS client is constructed (i.e. right after Aws::InitAPI).
+//! Install an AWS SDK HttpClientFactory routing all AWS SDK HTTP through DuckDB's
+//! HTTPUtil, whichever transport the DatabaseInstance has registered (httpfs curl on
+//! native, browser fetch under wasm). Lets the extension build for wasm without
+//! libcurl, and unifies proxy, CA certs and logging everywhere. Call once at
+//! extension load, BEFORE any AWS client is constructed.
 void RegisterDuckDBAwsHttpClientFactory(DatabaseInstance &db);
 
 } // namespace duckdb

--- a/src/rds/rds_storage.cpp
+++ b/src/rds/rds_storage.cpp
@@ -1,3 +1,4 @@
+#include "aws_http_client.hpp"
 #include "rds/rds_utils.hpp"
 
 #include "aws_client.hpp"
@@ -77,6 +78,7 @@ unique_ptr<Catalog> RdsAttach(optional_ptr<StorageExtensionInfo> storage_info, C
 	if (!Settings::Get<EnableExternalAccessSetting>(context)) {
 		throw PermissionException("Attaching RDS databases is disabled through configuration");
 	}
+	AwsInstanceBinding aws_binding(DatabaseInstance::GetDatabase(context));
 
 	auto instance_id = info.path;
 	if (instance_id.empty()) {

--- a/src/redshift/redshift_storage.cpp
+++ b/src/redshift/redshift_storage.cpp
@@ -1,3 +1,4 @@
+#include "aws_http_client.hpp"
 #include "redshift/redshift_utils.hpp"
 
 #include "aws_client.hpp"
@@ -85,6 +86,7 @@ unique_ptr<Catalog> RedshiftAttach(optional_ptr<StorageExtensionInfo> storage_in
 	if (!Settings::Get<EnableExternalAccessSetting>(context)) {
 		throw PermissionException("Attaching Redshift databases is disabled through configuration");
 	}
+	AwsInstanceBinding aws_binding(DatabaseInstance::GetDatabase(context));
 
 	auto attach_options = ParseAttachOptions(options);
 	auto cluster_id = info.path;

--- a/test/sql/aws_network_via_duckdb_setting.test
+++ b/test/sql/aws_network_via_duckdb_setting.test
@@ -1,0 +1,33 @@
+# name: test/sql/aws_network_via_duckdb_setting.test
+# description: aws_network_calls_via_duckdb must be global, so the AWS HTTP client factory can read it
+# group: [sql]
+
+require aws
+
+query I
+SELECT current_setting('aws_network_calls_via_duckdb')::BOOLEAN;
+----
+true
+
+statement ok con1
+SET aws_network_calls_via_duckdb=false;
+
+# The client factory reads this off the DatabaseInstance, which only sees the global
+# DBConfig - a session-scoped value would be invisible there and a plain SET would
+# silently do nothing. A second connection observing the change proves it landed globally.
+query I con2
+SELECT current_setting('aws_network_calls_via_duckdb')::BOOLEAN;
+----
+false
+
+statement ok con2
+SET GLOBAL aws_network_calls_via_duckdb=true;
+
+query I con1
+SELECT current_setting('aws_network_calls_via_duckdb')::BOOLEAN;
+----
+true
+
+statement error con1
+SET aws_network_calls_via_duckdb='not a boolean';
+----


### PR DESCRIPTION
Adds also a setting `aws_network_calls_via_duckdb` that allows to decide at runtime on behaviour. Setting default is `true`, so wiring them via this new infrastructure, but `SET aws_network_calls_via_duckdb = false;` remains available to go back to current behaviour.

Plan would be (at a later point, after proper validation) to completely remove the `curl` dependency and move to a single duckdb-based networking stack, allowing full control over proxies / retries / User-Agent / CA-certificates. This is a blocker for porting to platforms where native curl is not available, but they might have custom implementations of the network stack.