### PR TITLE
Check expiration epoch for aws credentials

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -6,6 +6,8 @@ duckdb_extension_load(aws
     LOAD_TESTS
 )
 
+duckdb_extension_load(icu)
+
 # Build the postgres scanner for the redshift action (e.g. redshift attach).
 # Currently Disabled since this will not build on CI. To get CI working you (most likely)
 # need to copy the vcpkg_ports/libpq in the duckdb/duckdb-postgres repo. 

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -4,6 +4,7 @@
 
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/logging/logger.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 
@@ -445,11 +446,23 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 		result->secret_map["secret"] = Value(credentials.GetAWSSecretKey());
 		result->secret_map["session_token"] = Value(credentials.GetSessionToken());
 
-		// Store credential expiration as epoch seconds so consumers (e.g., duckdb-iceberg)
+		// Store credential expiration as epoch milliseconds so consumers (e.g., duckdb-iceberg)
 		// can refresh proactively at ~80% TTL instead of guessing with a fixed timer.
-		auto expiration = credentials.GetExpiration();
-		if (expiration != Aws::Utils::DateTime()) {
-			result->secret_map["expiration_epoch"] = Value::BIGINT(expiration.Seconds());
+		if (chain == "sts") {
+			// For the STS chain we cannot read the real expiration from `credentials.GetExpiration()`:
+			// the SDK's STSAssumeRoleCredentialsProvider builds the returned AWSCredentials with the
+			// 3-arg constructor, which leaves m_expiration at its default sentinel (time_point::max,
+			// i.e. year 294247). The true expiry is kept private in the provider's m_expiry and is
+			// never exposed. Since we always request STS credentials with a duration of
+			// DEFAULT_CREDS_LOAD_FREQ_SECONDS, compute the expiration from now() + that duration.
+			int64_t now_epoch_ms = Timestamp::GetEpochMs(Timestamp::GetCurrentTimestamp());
+			int64_t expiration_epoch_ms = now_epoch_ms + (Aws::Auth::DEFAULT_CREDS_LOAD_FREQ_SECONDS * 1000LL);
+			result->secret_map["expiration_epoch_ms"] = Value::BIGINT(expiration_epoch_ms);
+		} else {
+			auto expiration = credentials.GetExpiration();
+			if (expiration != Aws::Utils::DateTime()) {
+				result->secret_map["expiration_epoch_ms"] = Value::BIGINT(expiration.Millis());
+			}
 		}
 	}
 

--- a/test/sql/aws_test_epoch.test
+++ b/test/sql/aws_test_epoch.test
@@ -1,0 +1,45 @@
+# name: test/sql/aws_test_epoch.test
+# description: test integration with iceberg catalog read
+# group: [sql]
+
+require httpfs
+
+require parquet
+
+require aws
+
+require icu
+
+require-env AWS_CONFIG_FILE
+
+require-env AWS_SHARED_CREDENTIALS_FILE
+
+# needs to run against actual aws credentials
+require-env AWS_CREDENTIALS_AVAIABLE
+
+statement ok
+CREATE SECRET glue_secret (
+    TYPE AWS,
+    PROVIDER credential_chain,
+    CHAIN 'sts',
+    ASSUME_ROLE_ARN 'arn:aws:iam::840140254803:role/pyiceberg-etl-role',
+    REGION 'us-east-1'
+);
+
+statement ok
+select sleep_ms(1000);
+
+# test that expiration_epoch_ms is <900 seconds for sts
+query I
+WITH secret_fields AS (
+    FROM duckdb_secrets()
+    SELECT unnest(list_apply(string_split(secret_string, ';'), lambda x: string_split(x, '='))) AS elements
+),
+ttl AS (
+    SELECT elements[2]::BIGINT - epoch_ms(now())::BIGINT AS ttl_ms
+    FROM secret_fields
+    WHERE elements[1] = 'expiration_epoch_ms'
+)
+SELECT ttl_ms > 800000 AND ttl_ms < 900000 FROM ttl;
+----
+true


### PR DESCRIPTION
STS doesn't report the proper expiration time for STS credentials. Currently duckdb always requests these credentials with a default expiration value of 900 seconds. Now we add the proper expiration time as a `expiration_epoch_ms` to the secret string.

This is only for sts, I would eventually like to test for sso, instance, and other secret generating credential chains as well