### PR TITLE
Add 'container' credential chain token for ECS/EKS container credentials

### DIFF
--- a/.github/workflows/MinioTests.yml
+++ b/.github/workflows/MinioTests.yml
@@ -87,6 +87,15 @@ jobs:
           export AWS_SHARED_CREDENTIALS_FILE="$HOME/.aws/credentials";
           ./build/release/test/unittest "*/test/sql/env/*"
 
+      - name: Run container credentials env tests
+        shell: bash
+        env:
+          AWS_CONTAINER_CREDENTIALS_FULL_URI: http://127.0.0.1:8899/creds
+          AWS_CONTAINER_AUTHORIZATION_TOKEN: duckdb-container-test-token
+        run: |
+          python3 ./scripts/run_container_credentials_test_server.py 8899 duckdb-container-test-token &
+          sleep 1
+          ./build/release/test/unittest test/sql/env/aws_secret_container_env.test
 
       - name: Run mitmproxy
         shell: bash

--- a/scripts/run_container_credentials_test_server.py
+++ b/scripts/run_container_credentials_test_server.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Mock container-credentials endpoint (ECS task role / EKS Pod Identity) for tests.
+
+Serves the JSON document the real 169.254.170.2 endpoint returns, on loopback so the
+AWS SDK's GeneralHTTPCredentialsProvider accepts the AWS_CONTAINER_CREDENTIALS_FULL_URI.
+
+Usage: run_container_credentials_test_server.py [port] [expected_authorization]
+
+If expected_authorization is given, requests whose Authorization header does not match
+are rejected with 401 — a passing test then proves AWS_CONTAINER_AUTHORIZATION_TOKEN
+was forwarded by the provider.
+"""
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+EXPECTED_AUTHORIZATION = sys.argv[2] if len(sys.argv) > 2 else None
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if EXPECTED_AUTHORIZATION and self.headers.get("Authorization") != EXPECTED_AUTHORIZATION:
+            self.send_response(401)
+            self.end_headers()
+            sys.stdout.write(f"rejected: Authorization={self.headers.get('Authorization')}\n")
+            sys.stdout.flush()
+            return
+        expiration = (datetime.now(timezone.utc) + timedelta(hours=6)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        body = json.dumps(
+            {
+                "AccessKeyId": "ASIAMOCKCONTAINERKEY",
+                "SecretAccessKey": "mock-container-secret-key",
+                "Token": "mock-container-session-token",
+                "Expiration": expiration,
+                "RoleArn": "arn:aws:iam::123456789012:role/mock-task-role",
+            }
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+        sys.stdout.write(f"served: {self.path}\n")
+        sys.stdout.flush()
+
+    def log_message(self, *args):
+        pass
+
+
+if __name__ == "__main__":
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8899
+    HTTPServer(("127.0.0.1", port), Handler).serve_forever()

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -10,11 +10,13 @@
 
 #include <aws/core/Aws.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
+#include <aws/core/auth/GeneralHTTPCredentialsProvider.h>
 #include <aws/core/auth/SSOCredentialsProvider.h>
 #include <aws/core/auth/STSCredentialsProvider.h>
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/config/AWSConfigFileProfileConfigLoader.h>
 #include <aws/core/config/AWSProfileConfigLoaderBase.h>
+#include <aws/core/platform/Environment.h>
 #include <aws/identity-management/auth/STSAssumeRoleCredentialsProvider.h>
 #include <aws/rds/RDSClient.h>
 #include <aws/sts/STSClient.h>
@@ -152,6 +154,24 @@ public:
 				/* Credentials provider implementation that loads credentials from the Amazon EC2 Instance Metadata
 				 * Service. */
 				AddProvider(std::make_shared<Aws::Auth::InstanceProfileCredentialsProvider>());
+			} else if (item == "container") {
+				// Container credentials (ECS task role, EKS Pod Identity): resolved from the endpoint
+				// advertised by the AWS_CONTAINER_* environment variables the container runtime sets,
+				// constructed the same way the SDK's DefaultAWSCredentialsProviderChain does it.
+				// https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html
+				using Aws::Auth::GeneralHTTPCredentialsProvider;
+				auto container_provider = std::make_shared<GeneralHTTPCredentialsProvider>(
+				    Aws::Environment::GetEnv(GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_RELATIVE_URI),
+				    Aws::Environment::GetEnv(GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_FULL_URI),
+				    Aws::Environment::GetEnv(GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN),
+				    Aws::Environment::GetEnv(GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE));
+				if (!container_provider->IsValid()) {
+					throw InvalidConfigurationException(
+					    "Chain value 'container' requires container credentials to be available: "
+					    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI or AWS_CONTAINER_CREDENTIALS_FULL_URI must be set in "
+					    "the environment (ECS and EKS Pod Identity set these automatically)");
+				}
+				AddProvider(std::move(container_provider));
 			} else if (item == "web_identity") {
 				Aws::Client::ClientConfiguration::CredentialProviderConfiguration config;
 				if (!assume_role_arn.empty()) {
@@ -240,8 +260,8 @@ static string ConstructErrorMessage(string chain, string profile, string assume_
 	// these chains "generate" new aws keys. See their documentation in the header file
 	// https://github.com/aws/aws-sdk-cpp/blob/main/src/aws-cpp-sdk-core/include/aws/core/auth/AWSCredentialsProvider.h
 	// if a roll is assumed, secrets are also "generated"
-	if (chain == "sts" || chain == "sso" || chain == "instance" || chain == "process" || chain == "web_identity" ||
-	    !assume_role.empty()) {
+	if (chain == "sts" || chain == "sso" || chain == "instance" || chain == "container" || chain == "process" ||
+	    chain == "web_identity" || !assume_role.empty()) {
 		verb = "generate";
 	}
 	string prefix = StringUtil::Format("Secret Validation Failure: during `%s` using the following:\n", verb);

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -4,6 +4,7 @@
 
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/file_system.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/logging/logger.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
@@ -16,7 +17,6 @@
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/config/AWSConfigFileProfileConfigLoader.h>
 #include <aws/core/config/AWSProfileConfigLoaderBase.h>
-#include <aws/core/platform/Environment.h>
 #include <aws/identity-management/auth/STSAssumeRoleCredentialsProvider.h>
 #include <aws/rds/RDSClient.h>
 #include <aws/sts/STSClient.h>
@@ -161,10 +161,10 @@ public:
 				// https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html
 				using Aws::Auth::GeneralHTTPCredentialsProvider;
 				auto container_provider = std::make_shared<GeneralHTTPCredentialsProvider>(
-				    Aws::Environment::GetEnv(GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_RELATIVE_URI),
-				    Aws::Environment::GetEnv(GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_FULL_URI),
-				    Aws::Environment::GetEnv(GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN),
-				    Aws::Environment::GetEnv(GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE));
+				    FileSystem::GetEnvVariable(GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_RELATIVE_URI),
+				    FileSystem::GetEnvVariable(GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_FULL_URI),
+				    FileSystem::GetEnvVariable(GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN),
+				    FileSystem::GetEnvVariable(GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE));
 				if (!container_provider->IsValid()) {
 					throw InvalidConfigurationException(
 					    "Chain value 'container' requires container credentials to be available: "

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -369,6 +369,26 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 		}
 	}
 
+	// Log the container-credentials configuration when the chain includes 'container': the
+	// AWS_CONTAINER_* values decide whether the provider is usable, and failures otherwise leave
+	// no trace of what the environment contained. The auth token value itself is never logged.
+	for (const auto &item : StringUtil::Split(chain, ';')) {
+		if (item == "container") {
+			using Aws::Auth::GeneralHTTPCredentialsProvider;
+			DUCKDB_LOG_DEBUG(
+			    context,
+			    "aws.CredentialChain: container credentials config: relative_uri='%s', full_uri='%s', "
+			    "auth_token_file='%s', auth_token %s",
+			    FileSystem::GetEnvVariable(GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_RELATIVE_URI),
+			    FileSystem::GetEnvVariable(GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_FULL_URI),
+			    FileSystem::GetEnvVariable(GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE),
+			    FileSystem::GetEnvVariable(GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN).empty()
+			        ? "unset"
+			        : "set");
+			break;
+		}
+	}
+
 	// Region MUST be set according to the SDK https://docs.aws.amazon.com/sdkref/latest/guide/feature-region.html
 	string region = ResolveAwsRegion(context, TryGetStringParam(input, "region"), profile);
 

--- a/test/sql/aws_secret_chains.test
+++ b/test/sql/aws_secret_chains.test
@@ -127,3 +127,14 @@ CREATE SECRET web_identity_secret (
     CHAIN 'web_identity',
 	VALIDATION 'none'
 );
+
+# container chain (ECS task role / EKS Pod Identity) requires the AWS_CONTAINER_* env vars;
+# outside a container runtime it fails eagerly with a clear error, even with VALIDATION 'none'
+statement error
+CREATE SECRET container_secret (
+    TYPE S3,
+    PROVIDER credential_chain,
+    CHAIN 'container'
+);
+----
+<REGEX>:.*Invalid Configuration Error: Chain value 'container' requires container credentials to be available.*

--- a/test/sql/env/aws_secret_container_env.test
+++ b/test/sql/env/aws_secret_container_env.test
@@ -1,0 +1,46 @@
+# name: test/sql/env/aws_secret_container_env.test
+# description: chain 'container' resolves credentials from the container credentials endpoint (issue #170)
+# group: [env]
+
+require aws
+
+require httpfs
+
+# Requires scripts/run_container_credentials_test_server.py listening on the URI below,
+# started with the same authorization token as AWS_CONTAINER_AUTHORIZATION_TOKEN.
+require-env AWS_CONTAINER_CREDENTIALS_FULL_URI
+
+require-env AWS_CONTAINER_AUTHORIZATION_TOKEN
+
+statement ok
+CALL enable_logging(level='debug');
+
+statement ok
+set secret_directory='{TEST_DIR}/aws_secret_container_env'
+
+statement ok
+CREATE SECRET container_env_secret (
+    TYPE S3,
+    PROVIDER credential_chain,
+    CHAIN 'container',
+    REGION 'us-east-1'
+);
+
+# key material must come from the mock endpoint (which also enforces the Authorization
+# header, so this proves AWS_CONTAINER_AUTHORIZATION_TOKEN was forwarded)
+query I
+SELECT secret_string FROM duckdb_secrets() WHERE name='container_env_secret';
+----
+<REGEX>:.*key_id=ASIAMOCKCONTAINERKEY.*
+
+# the endpoint's credential expiration is propagated for proactive refresh
+query I
+SELECT secret_string FROM duckdb_secrets() WHERE name='container_env_secret';
+----
+<REGEX>:.*expiration_epoch_ms=[0-9]+.*
+
+# the container env-var configuration is logged at debug level (token value never logged)
+query I
+SELECT message FROM duckdb_logs WHERE message LIKE '%aws.CredentialChain: container credentials config%'
+----
+<REGEX>:.*full_uri='http://127\.0\.0\.1:[0-9]+/creds'.*auth_token set.*


### PR DESCRIPTION
Fixes #170.

## Problem

No `CHAIN` value maps to the container credentials endpoint (`AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` / `AWS_CONTAINER_CREDENTIALS_FULL_URI`) — the standard credential mechanism for ECS task roles and EKS Pod Identity. The SDK default chain does include it, but `rds` secrets require a non-empty `CHAIN`, so the default chain is unreachable for them: RDS IAM auth from any ECS/Fargate task fails with `Unable to generate RDS IAM token`. On EC2-backed ECS it is worse — `CHAIN 'instance'` resolves the container-instance role via IMDS instead of the task role, minting a token as the wrong principal that fails later with `FATAL: PAM authentication failed`.

This also affects `s3`/`aws` secrets: any explicit `CHAIN` loses access to container credentials, since only the implicit empty-`CHAIN` fallback reaches them.

## Change

Adds a `container` chain token (issue's suggested fix 2) to `DuckDBCustomAWSCredentialsProviderChain`:

- Constructs `Aws::Auth::GeneralHTTPCredentialsProvider` (the class formerly known as `TaskRoleCredentialsProvider`) from the four `AWS_CONTAINER_*` environment variables, exactly as the SDK's `DefaultAWSCredentialsProviderChain` does.
- Fails eagerly with a clear `Invalid Configuration Error` naming the env vars when the provider is not usable (env vars absent or malformed), so the ECS-on-EC2 wrong-principal case surfaces an immediate diagnosis at `CREATE SECRET` time.
- Adds `container` to the "generate" verb list in `ConstructErrorMessage`.

The name `container` follows AWS's cross-SDK terminology (the [container credential provider](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html) in the AWS SDKs and Tools Reference Guide, which specifies the `AWS_CONTAINER_*` variables; `ContainerCredentialsProvider` in Java, `fromContainerMetadata` in JS, `container-role` in botocore). Works for all secret types, e.g.:

```sql
CREATE SECRET rds_task (
    TYPE rds, PROVIDER credential_chain, CHAIN 'container',
    RDS_USER 'user', RDS_HOST 'host', RDS_PORT 5432, REGION 'us-east-1'
);
```

Since the provider populates expiration on its credentials, `expiration_epoch_ms` is stored on the secret as well, so consumers that refresh proactively (e.g. duckdb-iceberg) get correct TTL info.

Deliberately **not** included, to keep this tight:
- Fix 1 from the issue (making `CHAIN` optional for `rds` secrets with a default-chain fallback).
- Extending the auto-`refresh` special case (currently `sts`/`web_identity`) to `container`, although container credentials also expire — can follow up if desired.

## Testing

- Added an error-path case to `test/sql/aws_secret_chains.test` (`CHAIN 'container'` outside a container runtime → clear error), matching the style of the other chain-token tests.
- Verified the happy path manually against a mock loopback container-credentials endpoint (the probe from #170): with `AWS_CONTAINER_CREDENTIALS_FULL_URI` set, the endpoint is hit (including the `Authorization` header when `AWS_CONTAINER_AUTHORIZATION_TOKEN` is set) and the resulting secret contains the endpoint's key id, secret, session token, and correct `expiration_epoch_ms`.
- Full local suite passes (11 test cases, 125 assertions; env-gated tests skipped).
- [ ] TODO: end-to-end validation from a real ECS/Fargate task (RDS IAM attach via DuckLake) — I can report results from our deployment.
- [x] CI coverage for the happy path: `test/sql/env/aws_secret_container_env.test` runs against `scripts/run_container_credentials_test_server.py` (a loopback mock that enforces the `Authorization` header) in a dedicated MinioTests step, asserting resolved key material, propagated `expiration_epoch_ms`, and the debug log of the `AWS_CONTAINER_*` configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

