### PR TITLE
Resolve AWS_PROFILE for sso chain when secret has no PROFILE

### DIFF
--- a/.github/workflows/MinioTests.yml
+++ b/.github/workflows/MinioTests.yml
@@ -87,6 +87,15 @@ jobs:
           export AWS_SHARED_CREDENTIALS_FILE="$HOME/.aws/credentials";
           ./build/release/test/unittest "*/test/sql/env/*"
 
+      - name: Run AWS_PROFILE env tests
+        shell: bash
+        env:
+          DUCKDB_AWS_TESTING_ENV_AVAILABLE: 1
+          AWS_PROFILE: minio-testing-2
+        run: |
+          export AWS_CONFIG_FILE="$HOME/.aws/config";
+          export AWS_SHARED_CREDENTIALS_FILE="$HOME/.aws/credentials";
+          ./build/release/test/unittest test/sql/env/aws_secret_sso_profile_env.test
 
       - name: Run mitmproxy
         shell: bash

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -117,8 +117,7 @@ public:
 	                                                 const string &profile = "", const string &assume_role_arn = "",
 	                                                 const string &external_id = "",
 	                                                 const string &web_identity_token_file = "",
-	                                                 const string &session_name = "",
-	                                                 optional_ptr<ClientContext> context = nullptr) {
+	                                                 const string &session_name = "") {
 		auto chain_list = StringUtil::Split(credential_chain, ';');
 
 		for (const auto &item : chain_list) {
@@ -142,17 +141,11 @@ public:
 				if (!SELECTED_CURL_CERT_PATH.empty()) {
 					sso_config->caFile = SELECTED_CURL_CERT_PATH;
 				}
-				// Only the SDK's no-arg SSOCredentialsProvider constructor resolves
-				// AWS_PROFILE/AWS_DEFAULT_PROFILE (via GetConfigProfileName); the (profile, config)
-				// overload stores its argument verbatim. Since we need the overload for the CA
-				// config, resolve the profile name ourselves when the secret does not pin one (#177).
-				Aws::String sso_profile =
-				    profile.empty() ? Aws::Auth::GetConfigProfileName() : Aws::String(profile.c_str());
-				if (context) {
-					DUCKDB_LOG_DEBUG(*context, "aws.SSOCredentialsProvider: using profile '%s'",
-					                 string(sso_profile.c_str()));
+				if (profile.empty()) {
+					AddProvider(std::make_shared<Aws::Auth::SSOCredentialsProvider>(Aws::String(), sso_config));
+				} else {
+					AddProvider(std::make_shared<Aws::Auth::SSOCredentialsProvider>(profile.c_str(), sso_config));
 				}
-				AddProvider(std::make_shared<Aws::Auth::SSOCredentialsProvider>(sso_profile, sso_config));
 			} else if (item == "env") {
 				AddProvider(std::make_shared<Aws::Auth::EnvironmentAWSCredentialsProvider>());
 			} else if (item == "instance") {
@@ -335,6 +328,13 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 	Aws::Auth::AWSCredentials credentials;
 
 	string profile = TryGetStringParam(input, "profile");
+	if (profile.empty()) {
+		// The SDK providers taking an explicit profile name store it verbatim, so an empty
+		// string would select the literal profile "". Resolve the name here the way the SDK's
+		// no-arg constructors do: AWS_PROFILE, then AWS_DEFAULT_PROFILE, then "default" (#177).
+		profile = Aws::Auth::GetConfigProfileName().c_str();
+	}
+	DUCKDB_LOG_DEBUG(context, "aws.CredentialChain: using profile '%s'", profile);
 	string assume_role = TryGetStringParam(input, "assume_role_arn");
 	string external_id = TryGetStringParam(input, "external_id");
 	string chain = TryGetStringParam(input, "chain");
@@ -363,9 +363,9 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 		if (chain.empty()) {
 			throw InvalidConfigurationException("Invalid RDS secret parameters, 'CHAIN' option must be specified");
 		}
-		auto provider = Aws::MakeShared<DuckDBCustomAWSCredentialsProviderChain>(
-		    "rds", chain, require_credentials, profile, assume_role, external_id, web_identity_token_file, session_name,
-		    &context);
+		auto provider = Aws::MakeShared<DuckDBCustomAWSCredentialsProviderChain>("rds", chain, require_credentials,
+		                                                                         profile, assume_role, external_id,
+		                                                                         web_identity_token_file, session_name);
 		return CreateRDSSecretWithProvider(provider, input, region);
 	}
 
@@ -378,7 +378,7 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 
 	if (!chain.empty()) {
 		DuckDBCustomAWSCredentialsProviderChain provider(chain, require_credentials, profile, assume_role, external_id,
-		                                                 web_identity_token_file, session_name, &context);
+		                                                 web_identity_token_file, session_name);
 		credentials = provider.GetAWSCredentials();
 	} else {
 		if (input.options.find("profile") != input.options.end()) {

--- a/src/aws_secret.cpp
+++ b/src/aws_secret.cpp
@@ -117,7 +117,8 @@ public:
 	                                                 const string &profile = "", const string &assume_role_arn = "",
 	                                                 const string &external_id = "",
 	                                                 const string &web_identity_token_file = "",
-	                                                 const string &session_name = "") {
+	                                                 const string &session_name = "",
+	                                                 optional_ptr<ClientContext> context = nullptr) {
 		auto chain_list = StringUtil::Split(credential_chain, ';');
 
 		for (const auto &item : chain_list) {
@@ -141,11 +142,17 @@ public:
 				if (!SELECTED_CURL_CERT_PATH.empty()) {
 					sso_config->caFile = SELECTED_CURL_CERT_PATH;
 				}
-				if (profile.empty()) {
-					AddProvider(std::make_shared<Aws::Auth::SSOCredentialsProvider>(Aws::String(), sso_config));
-				} else {
-					AddProvider(std::make_shared<Aws::Auth::SSOCredentialsProvider>(profile.c_str(), sso_config));
+				// Only the SDK's no-arg SSOCredentialsProvider constructor resolves
+				// AWS_PROFILE/AWS_DEFAULT_PROFILE (via GetConfigProfileName); the (profile, config)
+				// overload stores its argument verbatim. Since we need the overload for the CA
+				// config, resolve the profile name ourselves when the secret does not pin one (#177).
+				Aws::String sso_profile =
+				    profile.empty() ? Aws::Auth::GetConfigProfileName() : Aws::String(profile.c_str());
+				if (context) {
+					DUCKDB_LOG_DEBUG(*context, "aws.SSOCredentialsProvider: using profile '%s'",
+					                 string(sso_profile.c_str()));
 				}
+				AddProvider(std::make_shared<Aws::Auth::SSOCredentialsProvider>(sso_profile, sso_config));
 			} else if (item == "env") {
 				AddProvider(std::make_shared<Aws::Auth::EnvironmentAWSCredentialsProvider>());
 			} else if (item == "instance") {
@@ -356,9 +363,9 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 		if (chain.empty()) {
 			throw InvalidConfigurationException("Invalid RDS secret parameters, 'CHAIN' option must be specified");
 		}
-		auto provider = Aws::MakeShared<DuckDBCustomAWSCredentialsProviderChain>("rds", chain, require_credentials,
-		                                                                         profile, assume_role, external_id,
-		                                                                         web_identity_token_file, session_name);
+		auto provider = Aws::MakeShared<DuckDBCustomAWSCredentialsProviderChain>(
+		    "rds", chain, require_credentials, profile, assume_role, external_id, web_identity_token_file, session_name,
+		    &context);
 		return CreateRDSSecretWithProvider(provider, input, region);
 	}
 
@@ -371,7 +378,7 @@ static unique_ptr<BaseSecret> CreateAWSSecretFromCredentialChain(ClientContext &
 
 	if (!chain.empty()) {
 		DuckDBCustomAWSCredentialsProviderChain provider(chain, require_credentials, profile, assume_role, external_id,
-		                                                 web_identity_token_file, session_name);
+		                                                 web_identity_token_file, session_name, &context);
 		credentials = provider.GetAWSCredentials();
 	} else {
 		if (input.options.find("profile") != input.options.end()) {

--- a/test/sql/aws_secret_chains.test
+++ b/test/sql/aws_secret_chains.test
@@ -56,6 +56,7 @@ CREATE SECRET sso_secret_no_profile (
 );
 ----
 <REGEX>:.*Invalid Configuration Error: Secret Validation Failure: during `generate` using the following:
+Profile: '.*'
 Credential Chain: 'sso'.*
 
 # same as above, !validation
@@ -97,6 +98,7 @@ CREATE SECRET env_secret (
 );
 ----
 <REGEX>:.*Invalid Configuration Error: Secret Validation Failure: during `create` using the following:
+Profile: '.*'
 Credential Chain: 'env'.*
 
 # same as above, !validation
@@ -117,6 +119,7 @@ CREATE SECRET web_identity_secret (
 );
 ----
 <REGEX>:.*Invalid Configuration Error: Secret Validation Failure: during `generate` using the following:
+Profile: '.*'
 Credential Chain: 'web_identity'.*
 
 # same as above, !validation

--- a/test/sql/aws_secret_sts_provider.test
+++ b/test/sql/aws_secret_sts_provider.test
@@ -58,6 +58,7 @@ CREATE or replace SECRET sts_secret (
 );
 ----
 <REGEX>:.*Invalid Configuration Error: Secret Validation Failure: during `generate` using the following:
+Profile: '.*'
 Credential Chain: 'sts'
 Role-arn: 'arn:aws:iam::840140254803:role/pyiceberg-etl-role'.*
 

--- a/test/sql/env/aws_secret_sso_profile_env.test
+++ b/test/sql/env/aws_secret_sso_profile_env.test
@@ -21,10 +21,10 @@ statement ok
 set secret_directory='{TEST_DIR}/aws_secret_sso_profile_env'
 
 # Real SSO cannot run in CI, so these tests assert profile-name *selection*, not the
-# SSO credential exchange: the provider logs which profile it will read, and
+# SSO credential exchange: secret creation logs which profile the chain will use, and
 # VALIDATION 'none' lets the secret be created even though no credentials result.
 
-# Without PROFILE, the SSO provider must use the profile named by AWS_PROFILE
+# Without PROFILE, the chain must use the profile named by AWS_PROFILE
 statement ok
 CREATE SECRET sso_env_profile (
     TYPE S3,
@@ -35,9 +35,9 @@ CREATE SECRET sso_env_profile (
 );
 
 query I
-SELECT message FROM duckdb_logs WHERE message LIKE '%SSOCredentialsProvider%'
+SELECT message FROM duckdb_logs WHERE message LIKE '%aws.CredentialChain: using profile%'
 ----
-<REGEX>:.*aws\.SSOCredentialsProvider: using profile 'minio-testing-2'.*
+<REGEX>:.*aws\.CredentialChain: using profile 'minio-testing-2'.*
 
 statement ok
 CALL truncate_duckdb_logs();
@@ -54,6 +54,6 @@ CREATE SECRET sso_pinned_profile (
 );
 
 query I
-SELECT message FROM duckdb_logs WHERE message LIKE '%SSOCredentialsProvider%'
+SELECT message FROM duckdb_logs WHERE message LIKE '%aws.CredentialChain: using profile%'
 ----
-<REGEX>:.*aws\.SSOCredentialsProvider: using profile 'minio-testing-invalid'.*
+<REGEX>:.*aws\.CredentialChain: using profile 'minio-testing-invalid'.*

--- a/test/sql/env/aws_secret_sso_profile_env.test
+++ b/test/sql/env/aws_secret_sso_profile_env.test
@@ -1,0 +1,59 @@
+# name: test/sql/env/aws_secret_sso_profile_env.test
+# description: chain 'sso' resolves the profile from AWS_PROFILE when the secret has no PROFILE (issue #177)
+# group: [env]
+
+require aws
+
+require httpfs
+
+require-env DUCKDB_AWS_TESTING_ENV_AVAILABLE
+
+require-env AWS_PROFILE minio-testing-2
+
+require-env AWS_CONFIG_FILE
+
+require-env AWS_SHARED_CREDENTIALS_FILE
+
+statement ok
+CALL enable_logging(level='debug');
+
+statement ok
+set secret_directory='{TEST_DIR}/aws_secret_sso_profile_env'
+
+# Real SSO cannot run in CI, so these tests assert profile-name *selection*, not the
+# SSO credential exchange: the provider logs which profile it will read, and
+# VALIDATION 'none' lets the secret be created even though no credentials result.
+
+# Without PROFILE, the SSO provider must use the profile named by AWS_PROFILE
+statement ok
+CREATE SECRET sso_env_profile (
+    TYPE S3,
+    PROVIDER credential_chain,
+    CHAIN 'sso',
+    REGION 'eu-west-1',
+    VALIDATION 'none'
+);
+
+query I
+SELECT message FROM duckdb_logs WHERE message LIKE '%SSOCredentialsProvider%'
+----
+<REGEX>:.*aws\.SSOCredentialsProvider: using profile 'minio-testing-2'.*
+
+statement ok
+CALL truncate_duckdb_logs();
+
+# An explicit PROFILE on the secret wins over AWS_PROFILE
+statement ok
+CREATE SECRET sso_pinned_profile (
+    TYPE S3,
+    PROVIDER credential_chain,
+    CHAIN 'sso',
+    PROFILE 'minio-testing-invalid',
+    REGION 'eu-west-1',
+    VALIDATION 'none'
+);
+
+query I
+SELECT message FROM duckdb_logs WHERE message LIKE '%SSOCredentialsProvider%'
+----
+<REGEX>:.*aws\.SSOCredentialsProvider: using profile 'minio-testing-invalid'.*


### PR DESCRIPTION
Fixes #177.

## Problem

The `sso` credential-chain token only works when the secret pins `PROFILE` explicitly.
Without it, `AWS_PROFILE`/`AWS_DEFAULT_PROFILE` are ignored and credential resolution
fails silently — unlike the AWS CLI/SDKs, where `AWS_PROFILE` selects the SSO profile.

This is a regression from #147: switching the empty-profile branch from the SDK's
no-arg `SSOCredentialsProvider` constructor to the `(profile, config)` overload was
needed to pass the CA-path `ClientConfiguration`, but only the no-arg constructor
resolves the profile name from the environment (via `GetConfigProfileName()`); the
overload stores its argument verbatim, so the provider read config for the literal
profile `""`.

## Fix

Resolve the profile name once in `CreateAWSSecretFromCredentialChain`, right where the
secret input is read (as suggested in review):

```cpp
string profile = TryGetStringParam(input, "profile");
if (profile.empty()) {
    profile = Aws::Auth::GetConfigProfileName().c_str();
}
```

Every chain token then sees the same effective profile, and `ResolveAwsRegion` — which
previously fell back to the literal `default` profile — now also honors `AWS_PROFILE`
for region-from-profile-config resolution. The CA-path `ClientConfiguration` from #147
is untouched.

The resolved profile is logged at debug level
(`aws.CredentialChain: using profile '...'`). Two reasons:
- Real SSO cannot run in CI, so the regression test asserts profile-name *selection*
  (not the SSO exchange) through `duckdb_logs`, following the pattern of
  `aws_secret_region_warning.test`.
- The SDK's SSO provider fails silently (empty credentials) when the profile has no
  usable SSO configuration, so the log line gives users a diagnostic for exactly this
  failure class (cf. #125).

Validation errors for chain secrets without an explicit `PROFILE` now name the
resolved profile (e.g. `Profile: 'default'`), since `ConstructErrorMessage` receives
it; affected test expectations are updated.

## Tests

- New `test/sql/env/aws_secret_sso_profile_env.test` (gated on
  `require-env AWS_PROFILE minio-testing-2`), run by a dedicated CI step:
  - a `CHAIN 'sso'` secret without `PROFILE` uses the profile named by `AWS_PROFILE`
  - an explicit `PROFILE` on the secret wins over `AWS_PROFILE`
- Written test-first: fails on main (no log emitted), passes with the fix.
- Full local suite passes, including the updated error-text expectations in
  `aws_secret_chains.test` and `aws_secret_sts_provider.test`.

## Manual verification (macOS, real AWS SSO profile)

- `AWS_PROFILE=<profile>` + secret without `PROFILE` → S3 read succeeds (previously HTTP 403)
- secret with `PROFILE '<profile>'`, no `AWS_PROFILE` → still succeeds (no regression)
- no profile anywhere → fails with 403 (confirms no ambient credentials in play)

## Notes

- Related issues possibly resolved or improved by this: #125 (SSO auth failing);
  #51 touches the adjacent profile-resolution area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)