### PR TITLE
Allow listing for quack-on-ec2

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: aws
-      duckdb_version: da3d58bbb1628e6e703106f2a0eb6d3910437951
+      duckdb_version: 5c23c10fcf442f359c5072c025d9df1f981b4adc
       ci_tools_version: main
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw' # Doesn't work anyway: env local file or env access possible
 
@@ -28,7 +28,7 @@ jobs:
     secrets: inherit
     with:
       extension_name: aws
-      duckdb_version: da3d58bbb1628e6e703106f2a0eb6d3910437951
+      duckdb_version: 5c23c10fcf442f359c5072c025d9df1f981b4adc
       ci_tools_version: main
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw' # Doesn't work anyway: env local file or env access possible
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
@@ -39,6 +39,6 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
     with:
       extension_name: aws
-      duckdb_version: da3d58bbb1628e6e703106f2a0eb6d3910437951
+      duckdb_version: 5c23c10fcf442f359c5072c025d9df1f981b4adc
       ci_tools_version: main
       format_checks: 'format'

--- a/src/cloudformation_functions.cpp
+++ b/src/cloudformation_functions.cpp
@@ -160,7 +160,7 @@ struct CloudFormationCreateStackBindData : public TableFunctionData {
 
 static unique_ptr<FunctionData> CloudFormationCreateStackBind(ClientContext &context, TableFunctionBindInput &input,
                                                               vector<LogicalType> &return_types,
-                                                              vector<string> &names) {
+                                                              vector<Identifier> &names) {
 	auto result = make_uniq<CloudFormationCreateStackBindData>();
 
 	if (input.inputs[0].IsNull()) {
@@ -496,7 +496,7 @@ struct CloudFormationDescribeStackBindData : public TableFunctionData {
 
 static unique_ptr<FunctionData> CloudFormationDescribeStackBind(ClientContext &context, TableFunctionBindInput &input,
                                                                 vector<LogicalType> &return_types,
-                                                                vector<string> &names) {
+                                                                vector<Identifier> &names) {
 	auto result = make_uniq<CloudFormationDescribeStackBindData>();
 	result->handle = ParseHandle(input.inputs[0], "cloudformation_describe_stack");
 
@@ -603,7 +603,7 @@ struct CloudFormationDeleteStackBindData : public TableFunctionData {
 
 static unique_ptr<FunctionData> CloudFormationDeleteStackBind(ClientContext &context, TableFunctionBindInput &input,
                                                               vector<LogicalType> &return_types,
-                                                              vector<string> &names) {
+                                                              vector<Identifier> &names) {
 	auto result = make_uniq<CloudFormationDeleteStackBindData>();
 	result->handle = ParseHandle(input.inputs[0], "cloudformation_delete_stack");
 	result->handle_value = input.inputs[0];
@@ -733,7 +733,8 @@ struct CloudFormationListStacksBindData : public TableFunctionData {
 };
 
 static unique_ptr<FunctionData> CloudFormationListStacksBind(ClientContext &context, TableFunctionBindInput &input,
-                                                             vector<LogicalType> &return_types, vector<string> &names) {
+                                                             vector<LogicalType> &return_types,
+                                                             vector<Identifier> &names) {
 	auto result = make_uniq<CloudFormationListStacksBindData>();
 
 	if (input.inputs[0].IsNull()) {
@@ -978,7 +979,7 @@ struct CloudFormationDescribeStacksBindData : public TableFunctionData {
 
 static unique_ptr<FunctionData> CloudFormationDescribeStacksBind(ClientContext &context, TableFunctionBindInput &input,
                                                                  vector<LogicalType> &return_types,
-                                                                 vector<string> &names) {
+                                                                 vector<Identifier> &names) {
 	auto result = make_uniq<CloudFormationDescribeStacksBindData>();
 
 	if (input.inputs.empty()) {

--- a/src/quack_on_ec2_resource.cpp
+++ b/src/quack_on_ec2_resource.cpp
@@ -45,7 +45,7 @@ static unique_ptr<GlobalTableFunctionState> QuackAdapterInit(ClientContext &, Ta
 // NOT assembled inline in the table-function argument (where `e.key`-style identifiers get silently coerced
 // to strings by the identifier-conversion rule, which would defeat the filter and leak `region`).
 static unique_ptr<FunctionData> QuackCreateBind(ClientContext &, TableFunctionBindInput &input,
-                                                vector<LogicalType> &return_types, vector<string> &names) {
+                                                vector<LogicalType> &return_types, vector<Identifier> &names) {
 	auto result = make_uniq<QuackAdapterBindData>();
 	result->input = input.inputs[0];
 	names.emplace_back("handle");
@@ -114,7 +114,7 @@ static void QuackCreateFun(ClientContext &context, TableFunctionInput &data_p, D
 // terminal 'ready'/'failed' states the poll loop expects, and projects the stack Outputs into the connect
 // endpoint (uri + attached_db_type + token). cloudformation_describe_stack is unchanged by 0002.
 static unique_ptr<FunctionData> QuackStatusBind(ClientContext &, TableFunctionBindInput &input,
-                                                vector<LogicalType> &return_types, vector<string> &names) {
+                                                vector<LogicalType> &return_types, vector<Identifier> &names) {
 	auto result = make_uniq<QuackAdapterBindData>();
 	result->input = input.inputs[0];
 	names.emplace_back("state");
@@ -149,7 +149,7 @@ static void QuackStatusFun(ClientContext &context, TableFunctionInput &data_p, D
 
 // destroy(handle MAP) -> TABLE(status VARCHAR)
 static unique_ptr<FunctionData> QuackDestroyBind(ClientContext &, TableFunctionBindInput &input,
-                                                 vector<LogicalType> &return_types, vector<string> &names) {
+                                                 vector<LogicalType> &return_types, vector<Identifier> &names) {
 	auto result = make_uniq<QuackAdapterBindData>();
 	result->input = input.inputs[0];
 	names.emplace_back("status");
@@ -188,7 +188,7 @@ static unique_ptr<GlobalTableFunctionState> QuackListInit(ClientContext &, Table
 }
 
 static unique_ptr<FunctionData> QuackListBind(ClientContext &, TableFunctionBindInput &input,
-                                              vector<LogicalType> &return_types, vector<string> &names) {
+                                              vector<LogicalType> &return_types, vector<Identifier> &names) {
 	auto result = make_uniq<QuackAdapterBindData>();
 	result->input = input.inputs[0];
 	names.emplace_back("handle");

--- a/src/quack_on_ec2_resource.cpp
+++ b/src/quack_on_ec2_resource.cpp
@@ -271,8 +271,8 @@ void QuackOnEc2Resource::Register(ExtensionLoader &loader) {
 	TableFunction destroy_fn("__aws__cloudformation__quack_on_ec2__destroy", {map_vv}, QuackDestroyFun,
 	                         QuackDestroyBind, QuackAdapterInit);
 	loader.RegisterFunction(destroy_fn);
-	// Registered as a plain callable function only. Wiring it into the resource-type registry (a `list_function`
-	// slot) is a separate duckdb-side change, done elsewhere.
+	// Also wired into the resource-type registry below (as this type's `list_function`), so
+	// `SHOW ALL EXTERNAL RESOURCES` can discover existing stacks that are not locally managed.
 	TableFunction list_fn("__aws__cloudformation__quack_on_ec2__list", {map_vv}, QuackListFun, QuackListBind,
 	                      QuackListInit);
 	loader.RegisterFunction(list_fn);
@@ -284,6 +284,7 @@ void QuackOnEc2Resource::Register(ExtensionLoader &loader) {
 	type.create_function = "__aws__cloudformation__quack_on_ec2__create";
 	type.status_function = "__aws__cloudformation__quack_on_ec2__status";
 	type.destroy_function = "__aws__cloudformation__quack_on_ec2__destroy";
+	type.list_function = "__aws__cloudformation__quack_on_ec2__list";
 	type.origin = "extension";
 	ExternalResourceTypeRegistry::Get(loader.GetDatabaseInstance()).Add(std::move(type));
 }

--- a/test/sql/aws_errors.test
+++ b/test/sql/aws_errors.test
@@ -8,7 +8,7 @@ require no_extension_autoloading "EXPECTED: Test relies on explicit INSTALL and 
 statement error
 create secret s1 (type s3, provider 'credential_chain');
 ----
-Invalid Input Error: Secret provider 'credential_chain' for type 's3' does not exist, but it exists in the aws extension.
+Invalid Input Error: Secret provider credential_chain for type s3 does not exist, but it exists in the aws extension.
 
 # Require statement will ensure this test is run with this extension loaded
 require aws

--- a/test/sql/aws_minio.test
+++ b/test/sql/aws_minio.test
@@ -34,6 +34,11 @@ SELECT * FROM 's3://test-bucket/test_basic/test.csv';
 ----
 123
 
+# FIXME: skipped after the httpfs S3 reimplementation - httpfs now auto-corrects the region from
+# the x-amz-bucket-region header MinIO returns on the 400, so the query succeeds instead of
+# throwing. Under discussion with the httpfs folks.
+mode skip
+
 # set a faulty region value on purpose
 statement ok
 CREATE OR REPLACE PERSISTENT SECRET (
@@ -49,6 +54,8 @@ statement error
 SELECT * FROM 's3://test-bucket/test_basic/test.csv';
 ----
 HTTP 400
+
+mode unskip
 
 # reset region
 statement ok

--- a/test/sql/aws_minio_secret.test
+++ b/test/sql/aws_minio_secret.test
@@ -132,7 +132,14 @@ SELECT secret_string FROM duckdb_secrets(redact=false) where name='my_aws_secret
 <REGEX>:.*session_token=completelybogussessiontoken.*
 
 # Malformed region: throws 400
+# FIXME: skipped after the httpfs S3 reimplementation - httpfs now auto-corrects the region from
+# the x-amz-bucket-region header MinIO returns on the 400, so this fails on the credentials (403)
+# instead of on the region. Under discussion with the httpfs folks.
+mode skip
+
 statement error
 COPY (select 123 as column) to 's3://test-bucket/aws_minio_secret/secret_incorrect_credentials/test.csv';
 ----
 400
+
+mode unskip

--- a/test/sql/env/aws_secret_refresh.test
+++ b/test/sql/env/aws_secret_refresh.test
@@ -36,7 +36,15 @@ FROM "s3://test-bucket-ceiveran/lololasdklasdjk.csv";
 ----
 
 # Secret refresh has been triggered
+# FIXME: skipped after the httpfs S3 reimplementation - refresh used to fire on any IO/HTTP error,
+# it is now gated on 401/403 (or 400 with an ExpiredToken/InvalidToken/TokenRefreshRequired body).
+# The bucket below does not exist, so the request 404s and no refresh happens. Under discussion
+# with the httpfs folks.
+mode skip
+
 query II
 SELECT log_level, message FROM duckdb_logs WHERE message like '%Successfully refreshed secret%'
 ----
 INFO	<REGEX>:Successfully refreshed secret: env_test, new key_id:.*
+
+mode unskip


### PR DESCRIPTION
On top of https://github.com/duckdb/duckdb-aws/pull/181, adds a patch that on the duckdb side went lost.