### PR TITLE
[ARN] Add `RedshiftTarget` for `redshift` service in `ARN` ATTACH delegation

### DIFF
--- a/src/arn_storage.cpp
+++ b/src/arn_storage.cpp
@@ -108,10 +108,39 @@ static ArnTarget RDSTarget(const ParsedArn &arn) {
 	return target;
 }
 
+static string RedshiftNamespaceResource(const ParsedArn &arn) {
+	static const string prefix = "namespace:";
+	if (!StringUtil::StartsWith(arn.resource, prefix) || arn.resource.size() == prefix.size()) {
+		throw InvalidInputException(
+		    "Expected a Redshift namespace ARN with a resource of the form 'namespace:<namespace-id>', got '%s'",
+		    arn.raw);
+	}
+	return arn.resource;
+}
+
+static ArnTarget RedshiftTarget(const ParsedArn &arn) {
+	if (arn.region.empty()) {
+		throw InvalidInputException("Redshift namespace ARN '%s' does not specify a region", arn.raw);
+	}
+	if (arn.account_id.empty()) {
+		throw InvalidInputException("Redshift namespace ARN '%s' does not specify an account ID", arn.raw);
+	}
+
+	ArnTarget target;
+	target.backend = "redshift";
+	target.path = RedshiftNamespaceResource(arn);
+	target.options["region"] = Value(arn.region);
+	target.options["account_id"] = Value(arn.account_id);
+	target.options["resource"] = Value(arn.resource);
+	target.autoload = false;
+	return target;
+}
+
 static const case_insensitive_map_t<arn_handler_t> &ArnServiceHandlers() {
 	static const case_insensitive_map_t<arn_handler_t> handlers {
 	    {"s3tables", S3TablesTarget},
 	    {"rds", RDSTarget},
+	    {"redshift", RedshiftTarget},
 	};
 	return handlers;
 }

--- a/src/include/redshift/redshift_utils.hpp
+++ b/src/include/redshift/redshift_utils.hpp
@@ -36,6 +36,12 @@ struct Redshift {
 	static RedshiftClusterInfo DescribeCluster(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider> &provider,
 	                                           const string &cluster_id, const string &region);
 
+	//! Resolve a provisioned Redshift namespace ARN's account/resource components to the cluster
+	//! identifier whose ClusterNamespaceArn matches. DescribeClusters is paginated when necessary.
+	static string ClusterIdentifierFromNamespace(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider> &provider,
+	                                             const string &account_id, const string &resource,
+	                                             const string &region);
+
 	//! Mint temporary database credentials for a cluster via `GetClusterCredentialsWithIAM`. The
 	//! provider supplies (and signs with) the AWS identity; the returned credentials are scoped to
 	//! the cluster and short-lived (see duration_seconds, default ~900s).

--- a/src/redshift/redshift_storage.cpp
+++ b/src/redshift/redshift_storage.cpp
@@ -24,6 +24,8 @@ namespace {
 struct RedshiftAttachOptions {
 	string secret_name;
 	string region;
+	string account_id;
+	string resource;
 	string db_name;
 	string host;
 	string port;
@@ -45,6 +47,10 @@ RedshiftAttachOptions ParseAttachOptions(AttachOptions &options) {
 		}
 		if (key == "region") {
 			parsed.region = value;
+		} else if (key == "account_id") {
+			parsed.account_id = value;
+		} else if (key == "resource") {
+			parsed.resource = value;
 		} else if (key == "database" || key == "dbname") {
 			parsed.db_name = value;
 		} else if (key == "host") {
@@ -80,13 +86,16 @@ unique_ptr<Catalog> RedshiftAttach(optional_ptr<StorageExtensionInfo> storage_in
 		throw PermissionException("Attaching Redshift databases is disabled through configuration");
 	}
 
+	auto attach_options = ParseAttachOptions(options);
 	auto cluster_id = info.path;
-	if (cluster_id.empty()) {
+	if (attach_options.account_id.empty() != attach_options.resource.empty()) {
+		throw InvalidInputException("Redshift namespace resolution requires both ACCOUNT_ID and RESOURCE");
+	}
+	if (cluster_id.empty() && attach_options.resource.empty()) {
 		throw BinderException("No Redshift cluster identifier given. Pass it as the ATTACH path, e.g. "
 		                      "ATTACH '<cluster-id>' AS db (TYPE redshift)");
 	}
 
-	auto attach_options = ParseAttachOptions(options);
 	auto secret_entry = FindAwsSecret(context, attach_options.secret_name);
 	const auto &secret = dynamic_cast<const KeyValueSecret &>(*secret_entry->secret);
 
@@ -105,6 +114,12 @@ unique_ptr<Catalog> RedshiftAttach(optional_ptr<StorageExtensionInfo> storage_in
 	auto postgres_extension = RequirePostgresStorageExtension(context, "a Redshift cluster");
 
 	auto provider = CredentialsProviderFromSecret(secret, "Redshift");
+	// The ARN trampoline injects these together. Resolving them here keeps all Redshift control-plane
+	// calls behind the Redshift storage layer while preserving direct TYPE redshift attaches.
+	if (!attach_options.resource.empty()) {
+		cluster_id = Redshift::ClusterIdentifierFromNamespace(provider, attach_options.account_id,
+		                                                      attach_options.resource, region);
+	}
 
 	// Anything ATTACH pins explicitly wins over what the cluster reports, so when it pins all of
 	// them there is nothing left to discover - skip the call rather than require the caller to

--- a/src/redshift/redshift_utils.cpp
+++ b/src/redshift/redshift_utils.cpp
@@ -3,6 +3,7 @@
 #include "aws_client.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 
 #include <aws/redshift/RedshiftClient.h>
@@ -59,6 +60,39 @@ RedshiftClusterInfo Redshift::DescribeCluster(const std::shared_ptr<Aws::Auth::A
 		    info.cluster_status);
 	}
 	return info;
+}
+
+string Redshift::ClusterIdentifierFromNamespace(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider> &provider,
+                                                const string &account_id, const string &resource,
+                                                const string &region) {
+	auto redshift_client = MakeClient(provider, region);
+	Aws::Redshift::Model::DescribeClustersRequest request;
+	auto expected_suffix = ":" + account_id + ":" + resource;
+
+	while (true) {
+		auto outcome = redshift_client.DescribeClusters(request);
+		if (!outcome.IsSuccess()) {
+			throw InvalidConfigurationException(
+			    "DescribeClusters failed while resolving Redshift namespace '%s' in account '%s' and region '%s': %s",
+			    resource, account_id, region, string(outcome.GetError().GetMessage().c_str()));
+		}
+
+		for (auto &cluster : outcome.GetResult().GetClusters()) {
+			auto namespace_arn = string(cluster.GetClusterNamespaceArn().c_str());
+			if (StringUtil::EndsWith(namespace_arn, expected_suffix)) {
+				return string(cluster.GetClusterIdentifier().c_str());
+			}
+		}
+
+		auto marker = outcome.GetResult().GetMarker();
+		if (marker.empty()) {
+			break;
+		}
+		request.SetMarker(marker);
+	}
+
+	throw InvalidConfigurationException("No Redshift cluster found for namespace '%s' in account '%s' and region '%s'",
+	                                    resource, account_id, region);
 }
 
 RedshiftIamCredentials

--- a/test/sql/redshift/redshift_arn_attach.test
+++ b/test/sql/redshift/redshift_arn_attach.test
@@ -1,0 +1,49 @@
+# name: test/sql/redshift/redshift_arn_attach.test
+# description: test attaching a Redshift cluster through its namespace ARN
+# group: [redshift]
+
+require aws
+
+require parquet
+
+# The 'aws' secret type is registered by httpfs.
+require httpfs
+
+require postgres_scanner
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+set ignore_error_messages
+
+statement ok
+LOAD aws
+
+statement ok
+CREATE SECRET (
+    TYPE s3,
+    KEY_ID '{AWS_ACCESS_KEY_ID}',
+    SECRET '{AWS_SECRET_ACCESS_KEY}',
+    REGION 'eu-central-1'
+);
+
+statement ok
+ATTACH 'arn:aws:redshift:eu-central-1:840140254803:namespace:e542f89f-b604-4110-a337-f7ba8c7ce156' AS redshift_db;
+
+statement ok
+select * from (show all tables) where database = 'redshift_db';
+
+query IIIIII
+select * from redshift_db.public.event order by all limit 10;
+----
+1	305	8	1851	Gotterdammerung	2008-01-25 14:30:00
+2	306	8	2114	Boris Godunov	2008-10-15 20:00:00
+3	302	8	1935	Salome	2008-04-19 14:30:00
+4	309	8	2090	La Cenerentola (Cinderella)	2008-09-21 14:30:00
+5	302	8	1982	Il Trovatore	2008-06-05 19:00:00
+6	308	8	2109	L Elisir d Amore	2008-10-10 19:30:00
+7	309	8	1891	Doctor Atomic	2008-03-06 14:00:00
+8	302	8	1832	The Magic Flute	2008-01-06 20:00:00
+9	308	8	2087	The Fly	2008-09-18 19:30:00
+10	305	8	2079	Rigoletto	2008-09-10 15:00:00

--- a/test/sql/storage/arn.test
+++ b/test/sql/storage/arn.test
@@ -31,7 +31,7 @@ Invalid Input Error: Invalid PARTITION Section of ARN: ''
 statement error
 ATTACH 'arn:aws::::' as db;
 ----
-Not implemented Error: ATTACH of AWS ARN service '' is not supported. Supported options are: rds, s3tables
+Not implemented Error: ATTACH of AWS ARN service '' is not supported. Supported options are: rds, redshift, s3tables
 
 # RDS dispatch only accepts DB instance ARNs, and the ARN owns its region.
 statement error
@@ -43,6 +43,22 @@ statement error
 ATTACH 'arn:aws:rds:eu-central-1:840140254803:db:instance' AS db (REGION 'us-east-1');
 ----
 Invalid Input Error: ATTACH option 'region' is derived from the ARN and cannot be set explicitly
+
+# Redshift dispatch only accepts namespace ARNs with a region and account ID.
+statement error
+ATTACH 'arn:aws:redshift:eu-central-1:840140254803:cluster:not-a-namespace' AS db;
+----
+Invalid Input Error: Expected a Redshift namespace ARN with a resource of the form 'namespace:<namespace-id>', got 'arn:aws:redshift:eu-central-1:840140254803:cluster:not-a-namespace'
+
+statement error
+ATTACH 'arn:aws:redshift:eu-central-1::namespace:e542f89f-b604-4110-a337-f7ba8c7ce156' AS db;
+----
+Invalid Input Error: Redshift namespace ARN 'arn:aws:redshift:eu-central-1::namespace:e542f89f-b604-4110-a337-f7ba8c7ce156' does not specify an account ID
+
+statement error
+ATTACH 'arn:aws:redshift:eu-central-1:840140254803:namespace:e542f89f-b604-4110-a337-f7ba8c7ce156' AS db (ACCOUNT_ID '123456789012');
+----
+Invalid Input Error: ATTACH option 'account_id' is derived from the ARN and cannot be set explicitly
 
 # Correctly delegates to iceberg, fails to load because we haven't 'require'd it in this test
 statement error


### PR DESCRIPTION
Follow up to #179 (and #183) and part of https://github.com/duckdblabs/duckdb-internal/issues/10049

### Summary

We `ATTACH` using the `Cluster namespace ARN` taken from the AWS Redshift web ui.

Extract the `account-id` and the `resource` part of the `ARN`, pass those to the `redshift` ATTACH as `account_id` and `resource` respectively.

For `Redshift` the `resource` part contains the `namespace:<namespace-id>`, we extract the `namespace-id` from that.

Then we iterate through the results of `DescribeClusters`, finding the `ClusterNamespaceArn` that ends on `:<account-id>:<resource>`, to then grab the `ClusterIdentifier` from the entry that arn belongs to, which finally gets us our `cluster_id` that we use for the remainder of the ATTACH path.