### PR TITLE
[Dev] Disable test that can't both work in `duckdb/duckdb-aws` and in `duckdb/duckdb` because it relies on the absence of an extension, which the tester can't guarantee

### DIFF
--- a/test/sql/storage/arn.test
+++ b/test/sql/storage/arn.test
@@ -60,14 +60,3 @@ ATTACH 'arn:aws:redshift:eu-central-1:840140254803:namespace:e542f89f-b604-4110-
 ----
 Invalid Input Error: ATTACH option 'account_id' is derived from the ARN and cannot be set explicitly
 
-statement ok
-set autoinstall_known_extensions = false;
-
-statement ok
-set autoload_known_extensions = false;
-
-# Correctly delegates to iceberg, fails to load because we haven't 'require'd it in this test
-statement error
-ATTACH 'arn:aws:s3tables:::' as db;
-----
-<REGEX>:.*iceberg.*


### PR DESCRIPTION
^ title