### PR TITLE
Add WebAssembly (DuckDB-Wasm) build support for aws extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,9 @@ set(EXTENSION_SOURCES src/arn_storage.cpp src/aws_extension.cpp src/aws_secret.c
                       src/quack_on_ec2_resource.cpp
                       src/redshift/redshift_utils.cpp src/redshift/redshift_storage.cpp
                       src/utils/utils.cpp)
+if(EMSCRIPTEN)
+    list(APPEND EXTENSION_SOURCES src/wasm_compat.c)
+endif()
 add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES})
 
 set(PARAMETERS "-warnings")

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -1,10 +1,53 @@
 # This file is included by DuckDB's build system. It specifies which extension to load
 
 # Extension from this repo
-duckdb_extension_load(aws
-    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    LOAD_TESTS
-)
+if (EMSCRIPTEN)
+    # For WebAssembly builds the loadable extension is produced by a plain
+    # `emcc <archive> -o <ext>.wasm -sSIDE_MODULE=2 ${LINKED_LIBS}` re-link
+    # (see build_loadable_extension_directory in duckdb), so the AWS SDK static
+    # libraries from vcpkg must be passed explicitly via LINKED_LIBS: they are
+    # NOT pulled in through target_link_libraries for that step.
+    # Paths are relative to build/<platform>/extension/aws/, where the
+    # POST_BUILD emcc command runs.
+    set(VCPKG_WASM_LIB_DIR "../../vcpkg_installed/wasm32-emscripten/lib")
+    string(JOIN " " AWS_WASM_LINKED_LIBS
+        "${VCPKG_WASM_LIB_DIR}/libaws-cpp-sdk-cloudformation.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-cpp-sdk-rds.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-cpp-sdk-redshift.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-cpp-sdk-identity-management.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-cpp-sdk-cognito-identity.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-cpp-sdk-sso.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-cpp-sdk-sts.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-cpp-sdk-core.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-crt-cpp.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-c-s3.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-c-auth.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-c-mqtt.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-c-event-stream.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-c-http.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-c-compression.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-c-io.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-c-cal.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-c-sdkutils.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-checksums.a"
+        "${VCPKG_WASM_LIB_DIR}/libaws-c-common.a"
+        "${VCPKG_WASM_LIB_DIR}/libs2n.a"
+        "${VCPKG_WASM_LIB_DIR}/libcurl.a"
+        "${VCPKG_WASM_LIB_DIR}/libssl.a"
+        "${VCPKG_WASM_LIB_DIR}/libcrypto.a"
+        "${VCPKG_WASM_LIB_DIR}/libz.a"
+    )
+    duckdb_extension_load(aws
+        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
+        LOAD_TESTS
+        LINKED_LIBS "${AWS_WASM_LINKED_LIBS}"
+    )
+else()
+    duckdb_extension_load(aws
+        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
+        LOAD_TESTS
+    )
+endif()
 
 duckdb_extension_load(icu)
 

--- a/src/wasm_compat.c
+++ b/src/wasm_compat.c
@@ -1,0 +1,28 @@
+// Compatibility shims for WebAssembly/Emscripten side-module builds.
+//
+// DuckDB-Wasm loadable extensions are linked with -sSIDE_MODULE=2: libc is
+// expected to come from the main module. The duckdb-wasm main module does not
+// export the network byte-order helpers, so provide them here (wasm32 is
+// little-endian, these are plain byte swaps).
+#ifdef __EMSCRIPTEN__
+
+#include <stdint.h>
+
+uint16_t htons(uint16_t x) {
+	return (uint16_t)((x << 8) | (x >> 8));
+}
+
+uint16_t ntohs(uint16_t x) {
+	return htons(x);
+}
+
+uint32_t htonl(uint32_t x) {
+	return ((x & 0x000000FFu) << 24) | ((x & 0x0000FF00u) << 8) | ((x & 0x00FF0000u) >> 8) |
+	       ((x & 0xFF000000u) >> 24);
+}
+
+uint32_t ntohl(uint32_t x) {
+	return htonl(x);
+}
+
+#endif

--- a/vcpkg-overlay-ports/README.md
+++ b/vcpkg-overlay-ports/README.md
@@ -1,0 +1,38 @@
+# vcpkg overlay ports for WebAssembly builds
+
+This directory contains vcpkg overlay ports needed to build this extension for
+the DuckDB-Wasm platforms (`wasm_mvp`, `wasm_eh`, `wasm_threads`).
+
+## aws-c-io
+
+Upstream `aws-c-io` (the AWS CRT I/O layer) refuses to configure for
+`wasm32-emscripten` with `"Event Loop is not setup on the platform."`, because it
+only knows the Windows (IOCP), Linux (epoll), Apple (dispatch queue) and BSD
+(kqueue) event loops.
+
+The `emscripten-support.patch` overlay adds an Emscripten platform branch that:
+
+- compiles the POSIX sources (sockets, pipes, DNS, shared-library stubs), which
+  build cleanly against Emscripten's musl libc;
+- ships **no** event loop implementation — `aws_event_loop_new*` fails
+  gracefully at runtime with `AWS_ERROR_PLATFORM_NOT_SUPPORTED` instead of
+  failing the build. The extension only uses the SDK's curl-style code paths,
+  so no event loop is ever required for the supported flows.
+
+Everything else in the dependency tree (openssl, curl, s2n, the remaining
+`aws-c-*` libraries, `aws-crt-cpp`, and `aws-sdk-cpp` itself) builds for
+`wasm32-emscripten` without modification.
+
+## Local usage
+
+```sh
+export VCPKG_OVERLAY_PORTS=$PWD/vcpkg-overlay-ports
+make wasm_eh
+```
+
+## CI usage
+
+The extension distribution CI (`_extension_distribution.yml` in
+duckdb/extension-ci-tools) sets `VCPKG_OVERLAY_PORTS` to
+`extension-ci-tools/vcpkg_ports`, so for CI wasm builds this port needs to land
+in that repository (or the CI needs to also honor a per-extension overlay dir).

--- a/vcpkg-overlay-ports/aws-c-io/emscripten-support.patch
+++ b/vcpkg-overlay-ports/aws-c-io/emscripten-support.patch
@@ -1,0 +1,36 @@
+--- a/CMakeLists.txt	2026-08-28 09:08:25
++++ b/CMakeLists.txt	2026-08-28 09:09:04
+@@ -116,6 +116,19 @@
+     list(APPEND EVENT_LOOP_DEFINES "KQUEUE")
+     set(USE_S2N ON)
+ 
++elseif (CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
++    # Emscripten/WebAssembly: no native event loop available. Compile the
++    # POSIX sources (sockets/pipes/dns compile against emscripten's musl libc)
++    # but no event loop implementation; event loop creation fails gracefully
++    # at runtime with AWS_ERROR_PLATFORM_NOT_SUPPORTED.
++    file(GLOB AWS_IO_OS_HEADERS)
++    file(GLOB AWS_IO_OS_SRC
++            "source/posix/*.c"
++            )
++    set(PLATFORM_LIBS "")
++    list(APPEND EVENT_LOOP_DEFINES "EMSCRIPTEN_NOOP")
++    set(USE_S2N ON)
++
+ endif()
+ 
+ if (BYO_CRYPTO)
+--- a/source/event_loop.c	2026-08-28 09:08:25
++++ b/source/event_loop.c	2026-08-28 09:10:14
+@@ -99,6 +99,11 @@
+     return AWS_EVENT_LOOP_EPOLL;
+ #elif defined(AWS_OS_WINDOWS)
+     return AWS_EVENT_LOOP_IOCP;
++#elif defined(__EMSCRIPTEN__)
++    /* No event loop implementation on WebAssembly/Emscripten. Return EPOLL so
++     * that aws_event_loop_type_validate_platform() fails gracefully with
++     * AWS_ERROR_PLATFORM_NOT_SUPPORTED instead of failing the build. */
++    return AWS_EVENT_LOOP_EPOLL;
+ #else
+ #    error                                                                                                             \
+         "Default event loop type required. Failed to get default event loop type. The library is not built correctly on the platform. "

--- a/vcpkg-overlay-ports/aws-c-io/portfile.cmake
+++ b/vcpkg-overlay-ports/aws-c-io/portfile.cmake
@@ -1,0 +1,34 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO awslabs/aws-c-io
+    REF "v${VERSION}"
+    SHA512 ba809c397ca824b9b56d3c73b9e1b18b955bc68f737700695b7d4242707ab570f1d80a1d74267b06b46e2c8b3fc307756883eff40959e6ddd34e2e7683a9ab2f
+    HEAD_REF master
+    PATCHES
+        emscripten-support.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DCMAKE_MODULE_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common" # use extra cmake files
+        -DBUILD_TESTING=FALSE
+)
+
+vcpkg_cmake_install()
+
+string(REPLACE "dynamic" "shared" subdir "${VCPKG_LIBRARY_LINKAGE}")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}/${subdir}" DO_NOT_DELETE_PARENT_CONFIG_PATH)
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake" [[/${type}/]] "/")
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/${PORT}"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/lib/${PORT}"
+)
+
+vcpkg_copy_pdbs()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-overlay-ports/aws-c-io/vcpkg.json
+++ b/vcpkg-overlay-ports/aws-c-io/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "aws-c-io",
+  "version": "0.24.0",
+  "port-version": 1,
+  "description": "Handles all IO and TLS work for application protocols.",
+  "homepage": "https://github.com/awslabs/aws-c-io",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "aws-c-cal",
+    "aws-c-common",
+    {
+      "name": "s2n",
+      "platform": "!uwp & !windows"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
# Add WebAssembly (DuckDB-Wasm) build support

Draft PR that makes the `aws` extension compile, link and load on the DuckDB-Wasm
platforms, addressing the extension side of
[duckdb-wasm#1919](https://github.com/duckdb/duckdb-wasm/issues/1919).

## What was blocking wasm builds

The CI currently excludes `wasm_mvp;wasm_eh;wasm_threads` with the comment
"Doesn't work anyway: env local file or env access possible". Three concrete
build blockers exist underneath that:

1. **`aws-c-io` does not configure for Emscripten**: it has no event loop for
   the platform and hard-fails CMake configure. Fixed with a vcpkg overlay port
   (`vcpkg-overlay-ports/aws-c-io/`) that compiles the POSIX sources without an
   event loop; event-loop creation fails gracefully at runtime with
   `AWS_ERROR_PLATFORM_NOT_SUPPORTED`. All other dependencies (openssl, curl,
   s2n, remaining CRT libs, aws-sdk-cpp) build for `wasm32-emscripten` unmodified.
2. **The AWS SDK never got linked into the loadable wasm module.** DuckDB's wasm
   extension link is a plain `emcc <archive> -o <ext>.wasm -sSIDE_MODULE=2
   ${LINKED_LIBS}` re-link that ignores `target_link_libraries`. Without
   `LINKED_LIBS`, every `Aws::*` symbol ends up as an unresolved `env` import.
   Fixed by passing the vcpkg static libraries via `LINKED_LIBS` in
   `extension_config.cmake` (Emscripten branch only).
3. **Byte-order helpers** (`ntohs`/`htons`/`ntohl`/`htonl`) are not exported by
   the duckdb-wasm main module; `src/wasm_compat.c` provides them so the side
   module is self-contained.

## Verified

Built `wasm_eh` against DuckDB v1.5.5 (emsdk 3.1.71, vcpkg at the repo baseline)
and verified with `@duckdb/duckdb-wasm` v1.5.5 in both Node and Chrome:

- `LOAD 'aws.duckdb_extension.wasm'` succeeds; extension registers.
- `CREATE SECRET (TYPE S3, PROVIDER credential_chain, CHAIN 'env'|'config')`
  fails gracefully with "no credentials found" (a browser sandbox has no env
  vars or `~/.aws` files).
- Tested on a node environment where it uses the credential chain to get the credentials from 'env' (process environment).

## Runtime caveats (why this is a draft)

- The default `credential_chain` probes IMDS/STS over raw sockets, which do not exist in a browser. With duckdb-wasm ≤ current, that path aborts on a missing `_ntohs` in duckdb-wasm's Emscripten JS glue (worth a companion fix in  duckdb-wasm); with it fixed, it would fail gracefully like env/config. 
- Making `credential_chain` genuinely useful in a browser needs a JS-side  credential callback in duckdb-wasm, however this is useful on node environments where a browser is not present. 

## Landing plan

- [ ] Companion change: `aws-c-io` overlay port must be reachable by CI:
  either merged into `duckdb/extension-ci-tools` `vcpkg_ports/` (preferred,
  drop-in: CI already sets `VCPKG_OVERLAY_PORTS` to that dir) or upstreamed to
  vcpkg/aws-c-io proper.
- [ ] Then remove `wasm_mvp;wasm_eh;wasm_threads` from `exclude_archs` in
  `.github/workflows/MainDistributionPipeline.yml` (left untouched here so CI
  stays green until the overlay port is available).
- [ ] Optional follow-up in duckdb-wasm: add the missing socket JS-library
  functions and/or a credential callback.

Let me know your thoughts guys. Both on the CI changes and the credentials fix ( this I think is better to be worked on other PR). 

Note the PR has been created with help of Fable. 

